### PR TITLE
NarUtil: use copyFile from commons-io so as to preserve timestamps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
       <version>1.8.1</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.8.1</version>

--- a/src/main/java/org/apache/maven/plugin/nar/NarUtil.java
+++ b/src/main/java/org/apache/maven/plugin/nar/NarUtil.java
@@ -453,7 +453,8 @@ public final class NarUtil
             if ( file.isFile() )
             {
                 // destination = destination.getParentFile();
-                FileUtils.copyFile( file, destination );
+                // use FileUtils from commons-io, because it preserves timestamps
+                org.apache.commons.io.FileUtils.copyFile( file, destination );
                 copied++;
 
                 // copy executable bit


### PR DESCRIPTION
Projects that are built from src/gnu/ sometimes re-run autoconf, because after copying configure might become older than configure.ac.
