### PR TITLE
Fixed dependency for cpptasks-parallel.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,9 @@
       </exclusions> 
     </dependency>
     <dependency>
-      <groupId>net.sf.antcontrib</groupId>
+      <groupId>org.codeswarm</groupId>
       <artifactId>cpptasks-parallel</artifactId>
-      <version>1.0-beta-5-parallel-1-SNAPSHOT</version>
+      <version>20121119</version>
     </dependency>
     <dependency>
       <groupId>org.apache.bcel</groupId>


### PR DESCRIPTION
The old one was not (automatically) found by maven. 
