### PR TITLE
Add a settings.xml for use with the BuildHive job

### DIFF
--- a/buildhive-settings.xml
+++ b/buildhive-settings.xml
@@ -1,0 +1,27 @@
+<!--
+	This file contains settings to let the BuildHive Job
+	https://buildhive.cloudbees.com/job/maven-nar/job/maven-nar-plugin/
+	find the cpptasks-parallel dependency (until we get it into
+	Maven Central or Codehaus).
+-->
+<settings>
+	<profiles>
+		<profile>
+			<id>imagej-repositories</id>
+			<repositories>
+				<repository>
+					<id>imagej.releases</id>
+					<url>http://maven.imagej.net/content/repositories/releases</url>
+				</repository>
+				<repository>
+					<id>imagej.snapshots</id>
+					<url>http://maven.imagej.net/content/repositories/snapshots</url>
+				</repository>
+			</repositories>
+		</profile>
+	</profiles>
+
+	<activeProfiles>
+		<activeProfile>imagej-repositories</activeProfile>
+	</activeProfiles>
+</settings>


### PR DESCRIPTION
We have a BuildHive job to provide continuous integration and testing here:

```
https://buildhive.cloudbees.com/job/maven-nar/job/maven-nar-plugin/
```

Unfortunately, the cpptasks-parallel artifact is not deployed anywhere,
and therefore the BuildHive job only succeeds sporadically (whenever the
cpptasks-parallel job has been built successfully, for a limited amount
of time).

BuildHive allows specifying a settings.xml file for such cases. Since we
deployed cpptasks-parallel to the ImageJ Maven repository, let's have
that file so that our BuildHive job fails only when the code has a
problem.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
