### PR TITLE
Fix it0016-layout

### DIFF
--- a/src/it/it0016-layout/it0016-lib-layout21/pom.xml
+++ b/src/it/it0016-layout/it0016-lib-layout21/pom.xml
@@ -46,7 +46,7 @@ under the License.
     <defaultGoal>install</defaultGoal>
     <plugins>
       <plugin>
-        <artifactId>maven-nar-plugin</artifactId>
+        <artifactId>nar-maven-plugin</artifactId>
         <extensions>true</extensions>
         <configuration>
           <layout>NarLayout21</layout>


### PR DESCRIPTION
This developer forgot that change in e95475ac(Completely rename the
plugin to 'nar-maven-plugin').

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
