### PR TITLE
Fix for issue: Compilers have to be configured in the pom.xml

### DIFF
--- a/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
+++ b/src/main/java/org/apache/maven/plugin/nar/AbstractCompileMojo.java
@@ -151,7 +151,7 @@ public abstract class AbstractCompileMojo
 
     protected final C getC()
     {
-        if ( onlySpecifiedCompilers && c == null )
+        if ( !onlySpecifiedCompilers && c == null )
         {
             setC( new C() );
         }
@@ -160,7 +160,7 @@ public abstract class AbstractCompileMojo
 
     protected final Cpp getCpp()
     {
-        if ( onlySpecifiedCompilers && cpp == null )
+        if ( !onlySpecifiedCompilers && cpp == null )
         {
             setCpp( new Cpp() );
         }
@@ -169,7 +169,7 @@ public abstract class AbstractCompileMojo
 
     protected final Fortran getFortran()
     {
-        if ( onlySpecifiedCompilers && fortran == null )
+        if ( !onlySpecifiedCompilers && fortran == null )
         {
             setFortran( new Fortran() );
         }


### PR DESCRIPTION
The onlySpecifiedCompilers flag was being used incorrectly.

This meant you had to specify a compiler in the configuration section in order to compiler native code:

```
    <configuration>
      <c>
        <includes>
          <include>**/*.c</include>
        </includes>
      </c>
   </configuration>
```

This was a regression bug, earlier versions did not require this specification.  This include file information is already specified in aol.properties.
