### PR TITLE
Commented-out classifier in components.xml (#35)

### DIFF
--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -88,7 +88,7 @@
 				<language>java</language>
 				<addedToClasspath>true</addedToClasspath>
 				<includesDependencies>false</includesDependencies>
-				<classifier />
+				<!-- NAR-193 (#35) <classifier /> -->
 			</configuration>
 		</component>
 


### PR DESCRIPTION
It turns out the Maven Source Plugin doesn't like it if the main artifact has the empty string as its classifier.  It will fail printing a warning saying:

> NOT adding sources to artifacts with classifier as Maven only supports one classifier per artifact.  Current artifact [xxxxx] has a [] classifier.

Apparently the classifier needs to be `null`, which means leaving off the `classifier` tag altogether in 'components.xml'.  We comment-out the tag and include a reference to the issue so we know why we did it.
