### PR TITLE
Do not ignore exit code in NarUtil#runCommand()

### DIFF
--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -213,7 +213,7 @@ public class Linker
         }
         else if ( name.equals( "msvc" ) )
         {
-            NarUtil.runCommand( "link", new String[] { "/?" }, null, null, out, err, dbg, log );
+            NarUtil.runCommand( "link", new String[] { "/?" }, null, null, out, err, dbg, log, true );
             Pattern p = Pattern.compile( "\\d+\\.\\d+\\.\\d+(\\.\\d+)?" );
             Matcher m = p.matcher( out.toString() );
             if ( m.find() )

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -604,7 +604,14 @@ public final class NarUtil
     }
 
     public static int runCommand( String cmd, String[] args, File workingDirectory, String[] env, TextStream out,
-                                  TextStream err, TextStream dbg, final Log log )
+           TextStream err, TextStream dbg, final Log log )
+        throws MojoExecutionException, MojoFailureException
+    {
+        return runCommand( cmd, args, workingDirectory, env, out, err, dbg, log, false );
+    }
+
+    public static int runCommand( String cmd, String[] args, File workingDirectory, String[] env, TextStream out,
+           TextStream err, TextStream dbg, final Log log, boolean expectFailure )
         throws MojoExecutionException, MojoFailureException
     {
         Commandline cmdLine = new Commandline();
@@ -654,7 +661,7 @@ public final class NarUtil
             final int timeout = 5000;
             errorGobbler.join( timeout );
             outputGobbler.join( timeout );
-            if ( exitValue != 0 )
+            if ( exitValue != 0 ^ expectFailure )
             {
                  if ( log == null )
                  {
@@ -668,8 +675,13 @@ public final class NarUtil
                       log.warn(out.toString());
                       log.warn(dbg.toString());
                  }
+                 throw new MojoExecutionException( "exit code: " + exitValue );
             }
             return exitValue;
+        }
+        catch ( MojoExecutionException e )
+        {
+            throw e;
         }
         catch ( Exception e )
         {


### PR DESCRIPTION
As discussed in https://github.com/maven-nar/nar-maven-plugin/pull/27
and https://github.com/maven-nar/nar-maven-plugin/issues/31 we cannot
simply expect all commands to be run via runCommand() to return an
exit code of 0: MSVC's linker, most notably, exits with at least the
codes 1140 and 1146 on two different systems when it is asked to show
its usage.

The suggested solution is to _expect_ a failure when launching this
particular command, and to finally throw an exception upon unexpected
exit codes.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
