### PR TITLE
Add a way to specify the OS rather than relying upon os.name

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -56,8 +56,7 @@ public abstract class AbstractNarMojo
      * The Architecture for the nar, Some choices are: "x86", "i386", "amd64", "ppc", "sparc", ... Defaults to a derived
      * value from ${os.arch}
      * 
-     * @parameter expression="${os.arch}"
-     * @required
+     * @parameter expression="${nar.arch}"
      */
     private String architecture;
 
@@ -65,7 +64,7 @@ public abstract class AbstractNarMojo
      * The Operating System for the nar. Some choices are: "Windows", "Linux", "MacOSX", "SunOS", ... Defaults to a
      * derived value from ${os.name} FIXME table missing
      * 
-     * @parameter expression="${os}"
+     * @parameter expression="${nar.os}"
      */
     private String os;
 

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -78,6 +78,9 @@ public final class NarUtil
 
     public static String getArchitecture( String architecture )
     {
+        if (architecture == null) {
+            return System.getProperty( "os.arch" );
+        }
         return architecture;
     }
 


### PR DESCRIPTION
In order to do cross-compilations (i.e. compile iOS on MacOSX or Android on Linux), it would be very helpful to be able to specify the OS from command line via a system property (similar to how os.arch can be specified).

This patch provides parameterization for nar.os (since you cannot change os.name without breaking other parts of maven) and also changes the parameterization for architecture to nar.arch (for consistency)
