### PR TITLE
Allow specifying a custom aol.properties file

### DIFF
--- a/src/main/java/com/github/maven_nar/NarProperties.java
+++ b/src/main/java/com/github/maven_nar/NarProperties.java
@@ -13,14 +13,14 @@ import org.codehaus.plexus.util.PropertyUtils;
 
 public class NarProperties {
 	
-	private final static String AOL_PROPERTIES = "aol.properties";
-	private final static String CUSTOM_AOL_PROPERTY_KEY = "nar.aolProperties";
-	private Properties properties;
-	private static NarProperties instance;
-	
-	private NarProperties(MavenProject project) throws MojoFailureException {
-		
-		Properties defaults = PropertyUtils.loadProperties( NarUtil.class.getResourceAsStream( AOL_PROPERTIES ) );
+    private final static String AOL_PROPERTIES = "aol.properties";
+    private final static String CUSTOM_AOL_PROPERTY_KEY = "nar.aolProperties";
+    private Properties properties;
+    private static NarProperties instance;
+
+    private NarProperties(MavenProject project) throws MojoFailureException {
+
+        Properties defaults = PropertyUtils.loadProperties( NarUtil.class.getResourceAsStream( AOL_PROPERTIES ) );
         if ( defaults == null )
         {
             throw new MojoFailureException( "NAR: Could not load default properties file: '"+AOL_PROPERTIES+"'." );
@@ -37,28 +37,25 @@ public class NarProperties {
                     // Try and read from the system property in case it's specified there
                     customPropertyLocation = System.getProperties().getProperty(CUSTOM_AOL_PROPERTY_KEY);
                 }
-                if (customPropertyLocation != null) {
-                    fis = new FileInputStream(customPropertyLocation);
-                } else {
-                    fis = new FileInputStream(project.getBasedir()+File.separator+AOL_PROPERTIES);
-                }
+                fis = new FileInputStream(customPropertyLocation != null ?
+                                          customPropertyLocation :
+                                          project.getBasedir()+File.separator+AOL_PROPERTIES);
                 properties.load( fis );
             }
-		} 
+        }
         catch (FileNotFoundException e) 
         {
-			// ignore (FIXME)
-			if (customPropertyLocation != null) {
-				// We tried loading from a custom location - so throw the exception
-				throw new MojoFailureException( "NAR: Could not load custom properties file: '"+
-												customPropertyLocation+
-												"'." );
-			}
-		} 
+            if (customPropertyLocation != null) {
+                // We tried loading from a custom location - so throw the exception
+                throw new MojoFailureException( "NAR: Could not load custom properties file: '"+
+                                                customPropertyLocation+
+                                                "'." );
+            }
+        }
         catch (IOException e) 
         {
-			// ignore (FIXME)
-		}
+            // ignore (FIXME)
+        }
         finally
         {
             try
@@ -74,33 +71,33 @@ public class NarProperties {
             }
         }
 
-	}
-	
-	/**
-	 * Retrieve the NarProperties
-	 * @param project may be null
-	 * @return
-	 * @throws MojoFailureException
-	 */
-	public static NarProperties getInstance(MavenProject project) throws MojoFailureException {
-		if (instance == null) {
-			instance = new NarProperties(project);
-		}
-		return instance;
-	}
-	
-	/**
-	 * Programmatically inject properties (and possibly overwrite existing properties)
-	 * @param project the current maven project
-	 * @param properties the properties from input stream
-	 */
-	public static void inject(MavenProject project, InputStream properties) throws MojoFailureException {
-		final Properties defaults = PropertyUtils.loadProperties( properties );
-		final NarProperties nar = getInstance(project);
-		nar.properties.putAll(defaults);
-	}
-	
-	public String getProperty(String key) {
-		return properties.getProperty(key);
-	}
+    }
+
+    /**
+     * Retrieve the NarProperties
+     * @param project may be null
+     * @return
+     * @throws MojoFailureException
+     */
+    public static NarProperties getInstance(MavenProject project) throws MojoFailureException {
+        if (instance == null) {
+            instance = new NarProperties(project);
+        }
+        return instance;
+    }
+
+    /**
+     * Programmatically inject properties (and possibly overwrite existing properties)
+     * @param project the current maven project
+     * @param properties the properties from input stream
+     */
+    public static void inject(MavenProject project, InputStream properties) throws MojoFailureException {
+        final Properties defaults = PropertyUtils.loadProperties( properties );
+        final NarProperties nar = getInstance(project);
+        nar.properties.putAll(defaults);
+    }
+
+    public String getProperty(String key) {
+        return properties.getProperty(key);
+    }
 }


### PR DESCRIPTION
Currently, new aol.properties values can be added by putting the file in the baseDirectory of the project.  This is not very helpful, for example, for projects that would like to share aol.properties files. 

This patch allows you to specify `nar.aolProperties` as a system define (via `-Dnar.aolProperties=path/to/aol.properties` on the command line) or by adding:

```
<nar.aolProperties>path/to/aol.properties<nar.aolProperties>
```

to the `<properties>` section of pom.xml.

When specifying a custom aol.properties file, if the file does not exist, then an exception is thrown.
