### PR TITLE
Add in the “-arch” flag for osx gpp compilers

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -566,13 +566,13 @@ ppc.MacOSX.linker=g++
 
 ppc.MacOSX.gpp.cpp.compiler=g++
 ppc.MacOSX.gpp.cpp.defines=Darwin GNU_GCC
-ppc.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith
+ppc.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -arch ppc
 ppc.MacOSX.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
 ppc.MacOSX.gpp.cpp.excludes=
 
 ppc.MacOSX.gpp.c.compiler=gcc
 ppc.MacOSX.gpp.c.defines=Darwin GNU_GCC
-ppc.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith
+ppc.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -arch ppc
 ppc.MacOSX.gpp.c.includes=**/*.c **/*.m
 ppc.MacOSX.gpp.c.excludes=
 
@@ -608,13 +608,13 @@ i386.MacOSX.linker=g++
 
 i386.MacOSX.gpp.cpp.compiler=g++
 i386.MacOSX.gpp.cpp.defines=Darwin GNU_GCC
-i386.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion
+i386.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -arch i386
 i386.MacOSX.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
 i386.MacOSX.gpp.cpp.excludes=
 
 i386.MacOSX.gpp.c.compiler=gcc
 i386.MacOSX.gpp.c.defines=Darwin GNU_GCC
-i386.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion
+i386.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -arch i386
 i386.MacOSX.gpp.c.includes=**/*.c **/*.m
 i386.MacOSX.gpp.c.excludes=
 
@@ -650,13 +650,13 @@ x86_64.MacOSX.linker=g++
 
 x86_64.MacOSX.gpp.cpp.compiler=g++
 x86_64.MacOSX.gpp.cpp.defines=Darwin GNU_GCC 
-x86_64.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion
+x86_64.MacOSX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -arch x86_64
 x86_64.MacOSX.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
 x86_64.MacOSX.gpp.cpp.excludes=
 
 x86_64.MacOSX.gpp.c.compiler=gcc
 x86_64.MacOSX.gpp.c.defines=Darwin GNU_GCC 
-x86_64.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion
+x86_64.MacOSX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -arch x86_64
 x86_64.MacOSX.gpp.c.includes=**/*.c **/*.m
 x86_64.MacOSX.gpp.c.excludes=
 


### PR DESCRIPTION
The OSX gcc compiler needs to have an `-arch XXX` flag passed to it or else it creates binaries for the current system.  This prevents you from specifying, for example `-Dnar.arch=i386` and actually getting i386 binaries from the compiler.

This patch adds the appropriate `-arch XXX` flags to the options in the default aol.properties.
