### PR TITLE
Allow specifying a custom aol.properties file

### DIFF
--- a/src/main/java/com/github/maven_nar/NarProperties.java
+++ b/src/main/java/com/github/maven_nar/NarProperties.java
@@ -14,6 +14,7 @@ import org.codehaus.plexus.util.PropertyUtils;
 public class NarProperties {
 	
 	private final static String AOL_PROPERTIES = "aol.properties";
+	private final static String CUSTOM_AOL_PROPERTY_KEY = "nar.aolProperties";
 	private Properties properties;
 	private static NarProperties instance;
 	
@@ -27,16 +28,26 @@ public class NarProperties {
         
         properties = new Properties(defaults);
         FileInputStream fis = null;
+        String customPropertyLocation = null;
         try 
         {
         	if (project != null) {
-        		fis = new FileInputStream(project.getBasedir()+File.separator+AOL_PROPERTIES);
+        		customPropertyLocation = project.getProperties().getProperty(CUSTOM_AOL_PROPERTY_KEY);
+        		if (customPropertyLocation == null) {
+        		    // Try and read from the system property in case it's specified there
+        		    customPropertyLocation = System.getProperties().getProperty(CUSTOM_AOL_PROPERTY_KEY);
+        		}
+        		fis = new FileInputStream(customPropertyLocation == null ? 
+        		                          customPropertyLocation : project.getBasedir()+File.separator+AOL_PROPERTIES);
         		properties.load( fis );
         	}
 		} 
         catch (FileNotFoundException e) 
         {
-			// ignore (FIXME)
+			if (customPropertyLocation != null) {
+			    // We tried loading from a custom location - so throw the exception
+			    throw new MojoFailureException( "NAR: Could not load custom properties file: '"+customPropertyLocation+"'." );
+			}
 		} 
         catch (IOException e) 
         {


### PR DESCRIPTION
Currently, new aol.properties values can be added by putting the file in the baseDirectory of the project. This is not very helpful, for example, for projects that would like to share aol.properties files.

This patch allows you to specify `nar.aolProperties` as a system define (via `-Dnar.aolProperties=path/to/aol.properties` on the command line) or by adding:

```
<nar.aolProperties>path/to/aol.properties<nar.aolProperties>
```

to the `<properties>` section of pom.xml.

When specifying a custom aol.properties file, if the file does not exist, then an exception is thrown.
