### PR TITLE
Add ability to specify the path of the desired tool

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -59,6 +59,13 @@ public abstract class Compiler
     private String name;
 
     /**
+     * Path location of the compile tool
+     *
+     * @parameter expression=""
+     */
+    private String toolPath;
+
+    /**
      * Source directory for native files
      * 
      * @parameter expression="${basedir}/src/main"
@@ -436,6 +443,12 @@ public abstract class Compiler
         CompilerEnum compilerName = new CompilerEnum();
         compilerName.setValue( name );
         compiler.setName( compilerName );
+
+        // tool path
+        if ( toolPath != null )
+        {
+            compiler.setToolPath( toolPath );
+        }
 
         // debug, exceptions, rtti, multiThreaded
         compiler.setDebug( debug );

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -61,6 +61,13 @@ public class Linker
     private String name;
 
     /**
+     * Path location of the linker tool
+     *
+     * @parameter expression=""
+     */
+    private String toolPath;
+
+    /**
      * Enables or disables incremental linking.
      * 
      * @parameter expression="" default-value="false"
@@ -276,6 +283,12 @@ public class Linker
         LinkerEnum linkerEnum = new LinkerEnum();
         linkerEnum.setValue( name );
         linker.setName( linkerEnum );
+
+        // tool path
+        if ( toolPath != null )
+        {
+            linker.setToolPath( toolPath );
+        }
 
         // incremental, map
         linker.setIncremental( incremental );

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -64,6 +64,7 @@ NAR Configuration
 
   <linker>
     <name/>
+    <toolPath/>
     <incremental/>
     <map/>
     <options>
@@ -87,6 +88,7 @@ NAR Configuration
 
   <cpp>
     <name/>
+    <toolPath/>
     <sourceDirectory/>
     <includes>
       <include>
@@ -278,6 +280,10 @@ the command line for compatible compilers/linkers. Default is false.
 	The Linker. Some choices are: "msvc", "g++", "CC", "icpc", ...
     Default is Architecture OS specific.
 
+** {linker toolPath}
+
+	The path that the linker is located within.  Default is to use the system's environment.
+
 ** {linker incremental}
 
 	Enables incremental linking. Default is false.
@@ -327,6 +333,10 @@ the command line for compatible compilers/linkers. Default is false.
 	The name of the compiler. Some choices are: "msvc", "g++", "gcc", "CC", "cc", "icc", "icpc", ...
     Default is AOL specific.
     
+** {cpp toolPath}
+
+	The path that the compiler is located within.  Default is to use the system's environment.
+
 ** {cpp sourceDirectory}
     
     Source directory for native files


### PR DESCRIPTION
By specifying `<toolPath>` in any of the configuration sections, you can point to a compiler/linker that is not in the standard (on your path) location.
