### PR TITLE
Don’t run/compile tests when cross-compiling

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -176,6 +176,8 @@ public abstract class AbstractNarMojo
 
 	private NarInfo narInfo;
 
+    private boolean crossCompile;
+
 	/**
 	 * Javah info
 	 * 
@@ -197,6 +199,7 @@ public abstract class AbstractNarMojo
         linker = NarUtil.getLinker( linker, getLog() );
 
         architecture = NarUtil.getArchitecture( architecture );
+        crossCompile = !(architecture.equalsIgnoreCase(System.getProperty("os.arch")));
         os = NarUtil.getOS( os );
         aolId = NarUtil.getAOL(mavenProject, architecture, os, linker, aol, getLog() );
         
@@ -310,6 +313,10 @@ public abstract class AbstractNarMojo
     protected final MavenProject getMavenProject()
     {
         return mavenProject;
+    }
+
+    protected boolean isCrossCompile() {
+        return crossCompile;
     }
 
     public final void execute()

--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -54,7 +54,7 @@ public class NarTestCompileMojo
     extends AbstractCompileMojo
 {
     /**
-     * Skip running of NAR integration test plugins.
+     * Skip running of NAR test plugins.
      * 
      * @parameter expression="${skipNar}" default-value="false"
      */
@@ -73,13 +73,19 @@ public class NarTestCompileMojo
     public final void narExecute()
         throws MojoExecutionException, MojoFailureException
     {
-    	super.narExecute();
-        // make sure destination is there
-        getTestTargetDirectory().mkdirs();
+        if ( skipNar ) {
+            getLog().info( "Nar test compilation is skipped." );
+        } else if ( isCrossCompile() ) {
+            getLog().info( "Not compiling cross-compiled nar tests." );
+        } else {
+            super.narExecute();
+            // make sure destination is there
+            getTestTargetDirectory().mkdirs();
 
-        for ( Iterator i = getTests().iterator(); i.hasNext(); )
-        {
-            createTest( getAntProject(), (Test) i.next() );
+            for ( Iterator i = getTests().iterator(); i.hasNext(); )
+            {
+                createTest( getAntProject(), (Test) i.next() );
+            }
         }
     }
 

--- a/src/main/java/com/github/maven_nar/NarTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestMojo.java
@@ -46,6 +46,13 @@ public class NarTestMojo
     extends AbstractCompileMojo
 {
     /**
+     * Skip running of NAR test plugins.
+     *
+     * @parameter expression="${skipNar}" default-value="false"
+     */
+    protected boolean skipNar;
+
+    /**
      * The classpath elements of the project being tested.
      * 
      * @parameter expression="${project.testClasspathElements}"
@@ -75,16 +82,22 @@ public class NarTestMojo
     public final void narExecute()
         throws MojoExecutionException, MojoFailureException
     {
-        super.narExecute();
-        // run all tests
-        for ( Iterator i = getTests().iterator(); i.hasNext(); )
-        {
-            runTest( (Test) i.next() );
-        }
+        if ( skipNar ) {
+            getLog().info( "Nar test execution is skipped." );
+        } else if ( isCrossCompile() ) {
+            getLog().info( "Not executing cross-compiled nar tests." );
+        } else {
+            super.narExecute();
+            // run all tests
+            for ( Iterator i = getTests().iterator(); i.hasNext(); )
+            {
+                runTest( (Test) i.next() );
+            }
 
-        for ( Iterator i = getLibraries().iterator(); i.hasNext(); )
-        {
-            runExecutable( (Library) i.next() );
+            for ( Iterator i = getLibraries().iterator(); i.hasNext(); )
+            {
+                runExecutable( (Library) i.next() );
+            }
         }
     }
 


### PR DESCRIPTION
When cross-compiling, it doesn’t make sense to run the tests (or even compile them) because they won’t actually execute.  We can determine if we are cross-compiling if `nar.arch` != `os.arch`.  In this situation, we can just skip the execution of the NarTestCompileMojo NarTestMojo.  The NarTestCompileMojo also has a skipNar flag which was not being used - and the same flag was added to the NarTestMojo (and used in both places).
