### PR TITLE
Fix NullPointerException from StreamHandler on failed execution.

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CaptureStreamHandler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CaptureStreamHandler.java
@@ -87,7 +87,7 @@ public class CaptureStreamHandler implements ExecuteStreamHandler {
 	 * it is returned; otherwise, standard output is returned.
 	 */
 	public String[] getOutput() {
-		return stderr.length > 0 ? stderr : stdout;
+		return (null != stderr && stderr.length > 0 ) ? stderr : stdout;
 	}
 
 	/** Gets the output of the execution's standard error stream. */


### PR DESCRIPTION
On Windows CPPTasks Unit tests where failing for gcc.
