### PR TITLE
added integration test for setting maven dependencies in javah classpath.

### DIFF
--- a/src/it/it0024-pom-dependencies/pom.xml
+++ b/src/it/it0024-pom-dependencies/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0024-pom-dependencies</artifactId>
+  <packaging>nar</packaging>
+
+  <name>NAR JNI Test</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Simple JNI Library
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <dependencies>
+    <dependency>
+      <groupId>gov.nist.math</groupId>
+      <artifactId>jama</artifactId>
+      <version>1.0.2</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <cpp>
+            <debug>true</debug>
+          </cpp>
+          <libraries>
+            <library>
+              <type>jni</type>
+              <narSystemPackage>it0024</narSystemPackage>
+              <linkCPP>false</linkCPP>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0024-pom-dependencies/src/main/c/HelloWorldJNI.c
+++ b/src/it/it0024-pom-dependencies/src/main/c/HelloWorldJNI.c
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <stdio.h>
+#include "it0024_HelloWorldJNI.h"
+
+JNIEXPORT jstring JNICALL Java_it0024_HelloWorldJNI_sayHello( JNIEnv *env, jobject obj ) {
+	jstring value;           /* the return value */
+
+	char buf[40];            /* working buffer (really only need 20 ) */
+
+
+	sprintf ( buf, "%s", "Hello NAR World!" );
+
+	value = (*env)->NewStringUTF( env, buf );
+
+	return value;
+}
+

--- a/src/it/it0024-pom-dependencies/src/main/java/it0024/HelloWorldJNI.java
+++ b/src/it/it0024-pom-dependencies/src/main/java/it0024/HelloWorldJNI.java
@@ -1,0 +1,43 @@
+package it0024;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import Jama.Matrix;
+
+public class HelloWorldJNI
+{
+    static
+    {
+        NarSystem.loadLibrary();
+    }
+
+    public final native String sayHello();
+
+    public void print( Matrix m )
+    {
+        System.out.println( m );
+    }
+
+    public static void main( String[] args )
+    {
+        HelloWorldJNI app = new HelloWorldJNI();
+        System.out.println( app.sayHello() );
+    }
+}

--- a/src/it/it0024-pom-dependencies/src/test/java/it0024/test/HelloWorldJNITest.java
+++ b/src/it/it0024-pom-dependencies/src/test/java/it0024/test/HelloWorldJNITest.java
@@ -1,0 +1,34 @@
+package it0024.test;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import it0024.HelloWorldJNI;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HelloWorldJNITest
+{
+    @Test public final void testNativeHelloWorldJNI()
+        throws Exception
+    {
+        HelloWorldJNI app = new HelloWorldJNI();
+        Assert.assertEquals( "Hello NAR World!", app.sayHello() );
+    }
+}


### PR DESCRIPTION
it0024.HelloWorldJNI imports Jama.Matrix (which is from a jama dependency
declared in the pom). nar-maven-plugin should put the corresponding jar on
the classpath when calling javah.

Currently it doesn't work for me, on Mac OS X 10.8.
