### PR TITLE
Handle empty <include> in <javah> section gracefully

### DIFF
--- a/src/it/it0003-jni/pom.xml
+++ b/src/it/it0003-jni/pom.xml
@@ -61,6 +61,11 @@ under the License.
               <linkCPP>false</linkCPP>
             </library>
           </libraries>
+          <javah>
+            <includes>
+              <include></include>
+            </includes>
+          </javah>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/github/maven_nar/Javah.java
+++ b/src/main/java/com/github/maven_nar/Javah.java
@@ -22,6 +22,7 @@ package com.github.maven_nar;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -179,6 +180,7 @@ public class Javah
 
     protected final Set getIncludes()
     {
+        NarUtil.removeNulls( includes );
         if ( includes.isEmpty() )
         {
             includes.add( "**/*.class" );

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -764,5 +765,14 @@ public final class NarUtil
         }
 
         return profiles;
+    }
+
+    static void removeNulls( Collection<?> collection )
+    {
+        for ( Iterator<?> iter = collection.iterator(); iter.hasNext(); ) {
+            if ( iter.next() == null ) {
+                iter.remove();
+            }
+        }
     }
 }


### PR DESCRIPTION
Before this patch, if you configuration contained something like

```
<javah>
    <includes>
        <include></include>
    </includes>
</javah>
```

the nar-javah goal would fail with a NullPointerException. Instead, we
handle such cases gracefully now, pretending that no include was specified
instead of an empty one.

This was reported as issue #17 by Christian Hammers. The resolution is
based on a suggestion by Greg Domjan.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
