### PR TITLE
Revert "Read the nar.properties from the ${buildDirectory}"

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -89,12 +89,6 @@ public abstract class AbstractNarMojo
     private File outputDirectory;
 
     /**
-     * @parameter property="project.build.outputDirectory"
-     * @readonly
-     */
-    protected File classesDirectory;
-
-    /**
      * Name of the output
      *  - for jni default-value="${project.artifactId}-${project.version}"
      *  - for libs default-value="${project.artifactId}-${project.version}"
@@ -353,12 +347,9 @@ public abstract class AbstractNarMojo
         {
             String groupId = getMavenProject().getGroupId();
             String artifactId = getMavenProject().getArtifactId();
-            String path = "META-INF/nar/" + groupId + "/" + artifactId + "/" + NarInfo.NAR_PROPERTIES;
-            File propertiesFile = new File( classesDirectory, path );
-            // should not need to try and read from source.
-            if( !propertiesFile.exists() ){
-                propertiesFile = new File( getMavenProject().getBasedir(), "src/main/resources/" + path);
-            }
+
+            File propertiesDir = new File( getMavenProject().getBasedir(), "src/main/resources/META-INF/nar/" + groupId + "/" + artifactId );
+            File propertiesFile = new File( propertiesDir, NarInfo.NAR_PROPERTIES );
 
             narInfo = new NarInfo(
                     groupId, artifactId,

--- a/src/main/java/com/github/maven_nar/NarPreparePackageMojo.java
+++ b/src/main/java/com/github/maven_nar/NarPreparePackageMojo.java
@@ -40,6 +40,12 @@ public class NarPreparePackageMojo
     extends AbstractNarMojo
 {    
     
+    /**
+     * @parameter property="project.build.outputDirectory"
+     * @readonly
+     */
+    protected File classesDirectory;
+
     // TODO: this is working of what is present rather than what was requested to be built, POM ~/= artifacts!
     public final void narExecute()
         throws MojoExecutionException, MojoFailureException


### PR DESCRIPTION
The regression introduced by this commit was that executables (which do
not want the version suffix in their file name) were built correctly
only until nar.properties were written into the buildDirectory: while
the executable does not want the version suffix, an associated .jar file
_does_ want that suffix, and that fact gets recorded in the
nar.properties. As a consequence, subsequent compile runs of the
executable would append the version suffix to their file names!

This reverts commit 4e85422f8907d738f0e2ae7dedfe6e7950802d17 and adds
the classesDirectory field to NarPreparePackageMojo (which needs that
parameter).

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
