### PR TITLE
Do not fall back on 'output' when requiring '<aol>.output'

### DIFF
--- a/src/main/java/com/github/maven_nar/NarInfo.java
+++ b/src/main/java/com/github/maven_nar/NarInfo.java
@@ -135,7 +135,7 @@ public class NarInfo
 
     public final String getOutput( AOL aol, String defaultOutput )
     {
-    	return getProperty( aol, "output", defaultOutput );
+        return getExactProperty( aol, "output", defaultOutput );
     }
 
     public final void setOutput( AOL aol, String value )
@@ -218,6 +218,17 @@ public class NarInfo
         String value = info.getProperty( key, defaultValue );
         value = aol == null ? value : info.getProperty( aol.toString() + "." + key, value );
         log.debug( "getProperty(" + aol + ", " + key + ", " + defaultValue + ") = " + value );
+        return value;
+    }
+
+    public final String getExactProperty( AOL aol, String key, String defaultValue )
+    {
+        if ( key == null )
+        {
+            throw new NullPointerException();
+        }
+        String value = info.getProperty( ( aol == null ? "" : aol.toString() + "." ) + key, defaultValue );
+        log.debug( "getExactProperty(" + aol + ", " + key + ", " + defaultValue + ") = " + value );
         return value;
     }
 


### PR DESCRIPTION
In particular when "cross" compiling for 32-bit in the same directory
as compiling for 64-bit (so that 'mvn deploy' will attach both
artifacts), it is important _not_ to fall back onto the 'output'
property when trying to determine the output name of the native
component: the previous run will have added the 'output' property
and the '<aol-64>.output' property so that '<aol-32>.output' does
not yet exist...

This only makes a difference for executables, as they do not want to
have the version suffix that shared libraries and .jar files would
want to have in their file names.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
