### PR TITLE
Add a code formatting template for Eclipse

### DIFF
--- a/config/eclipse-code-formatter-profile.xml
+++ b/config/eclipse-code-formatter-profile.xml
@@ -124,7 +124,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>


### PR DESCRIPTION
Eclipse has a powerful code formatter; by providing a standardized
code formatter template, we'll be able to make it much easier to keep
consistency with a single code formatting style.

Suggested by Greg Domjan.

Signed-off-by: Johannes Schindelin johannes.schindelin@gmx.de
