### PR TITLE
Use getBaseVersion() instead of getVersion() when constructing file paths

### DIFF
--- a/src/main/java/com/github/maven_nar/Lib.java
+++ b/src/main/java/com/github/maven_nar/Lib.java
@@ -134,7 +134,7 @@ public class Lib
                     File narDir =
                         new File( dependency.getFile().getParentFile(), "nar/lib/"
 									+ mojo.getAOL() + "/" + lib.type);
-                    String narName = dependency.getArtifactId() + "-" + lib.name + "-" + dependency.getVersion();
+                    String narName = dependency.getArtifactId() + "-" + lib.name + "-" + dependency.getBaseVersion();
 					lib.addLibSet(mojo, linker, antProject, narName, narDir);
 				}
 			}

--- a/src/main/java/com/github/maven_nar/NarArtifact.java
+++ b/src/main/java/com/github/maven_nar/NarArtifact.java
@@ -46,6 +46,6 @@ public class NarArtifact
     }
     
     public String getBaseFilename() {
-        return getArtifactId()+"-"+getVersion()+"-"+getClassifier();
+        return getArtifactId()+"-"+getBaseVersion()+"-"+getClassifier();
     }
 }

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -305,7 +305,7 @@ public class NarCompileMojo
                 File unpackDirectory = getUnpackDirectory();
                 File include =
                     getLayout().getIncludeDirectory( unpackDirectory, narDependency.getArtifactId(),
-                                                     narDependency.getVersion() );
+                                                     narDependency.getBaseVersion() );
                 getLog().debug( "Looking for include directory: " + include );
                 if ( include.exists() )
                 {
@@ -377,7 +377,7 @@ public class NarCompileMojo
 
                     File dir =
                         getLayout().getLibDirectory( unpackDirectory, dependency.getArtifactId(),
-                                                     dependency.getVersion(), aol.toString(), binding );
+                                                     dependency.getBaseVersion(), aol.toString(), binding );
 
                     getLog().debug("Looking for Library Directory: " + dir);
                     if ( dir.exists() )

--- a/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
@@ -761,7 +761,7 @@ public class NarIntegrationTestMojo
 
             // TODO: properties should be passed in here too
             surefireBooter.addTestSuite( "org.apache.maven.surefire.testng.TestNGXmlTestSuite", new Object[] {
-                suiteXmlFiles, testSourceDirectory.getAbsolutePath(), testNgArtifact.getVersion(),
+                suiteXmlFiles, testSourceDirectory.getAbsolutePath(), testNgArtifact.getBaseVersion(),
                 testNgArtifact.getClassifier(), properties, reportsDirectory } );
         }
         else
@@ -823,7 +823,7 @@ public class NarIntegrationTestMojo
             {
                 surefireBooter.addTestSuite( "org.apache.maven.surefire.testng.TestNGDirectoryTestSuite", new Object[] {
                     testClassesDirectory, includeList, excludeList, testSourceDirectory.getAbsolutePath(),
-                    testNgArtifact.getVersion(), testNgArtifact.getClassifier(), properties, reportsDirectory } );
+                    testNgArtifact.getBaseVersion(), testNgArtifact.getClassifier(), properties, reportsDirectory } );
             }
             else
             {

--- a/src/main/java/com/github/maven_nar/NarManager.java
+++ b/src/main/java/com/github/maven_nar/NarManager.java
@@ -252,7 +252,7 @@ public class NarManager
                         {
                             classifier = NarUtil.replace( "${aol}", aol.toString(), classifier );
                         }
-                        String version = nar.length >= 5 ? nar[4].trim() : dependency.getVersion();
+                        String version = nar.length >= 5 ? nar[4].trim() : dependency.getBaseVersion();
                         artifactList.add( new AttachedNarArtifact( groupId, artifactId, version, dependency.getScope(),
                                                                    ext, classifier, dependency.isOptional(), dependency.getFile() ));
                     }

--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -171,12 +171,12 @@ public class NarTestCompileMojo
             
             // check if it exists in the normal unpack directory
             File include = 
-                getLayout().getIncludeDirectory( getUnpackDirectory(), artifact.getArtifactId(), artifact.getVersion() );
+                getLayout().getIncludeDirectory( getUnpackDirectory(), artifact.getArtifactId(), artifact.getBaseVersion() );
             if ( !include.exists() )
             {
                 // otherwise try the test unpack directory
                 include = 
-                    getLayout().getIncludeDirectory( getTestUnpackDirectory(), artifact.getArtifactId(), artifact.getVersion() );
+                    getLayout().getIncludeDirectory( getTestUnpackDirectory(), artifact.getArtifactId(), artifact.getBaseVersion() );
             }
             if ( include.exists() )
             {                
@@ -289,7 +289,7 @@ public class NarTestCompileMojo
                 // check if it exists in the normal unpack directory 
                 File dir =
                     getLayout().getLibDirectory( getUnpackDirectory(), dependency.getArtifactId(),
-                                                  dependency.getVersion(), aol.toString(), binding );
+                                                  dependency.getBaseVersion(), aol.toString(), binding );
                 getLog().debug( "Looking for Library Directory: " + dir );
                 if ( !dir.exists() )
                 {
@@ -297,7 +297,7 @@ public class NarTestCompileMojo
 
                     // otherwise try the test unpack directory
                     dir = getLayout().getLibDirectory( getTestUnpackDirectory(), dependency.getArtifactId(),
-                                                        dependency.getVersion(), aol.toString(), binding );
+                                                        dependency.getBaseVersion(), aol.toString(), binding );
                     getLog().debug( "Looking for Library Directory: " + dir );
                 }
                 if ( dir.exists() )

--- a/src/main/java/com/github/maven_nar/NarTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestMojo.java
@@ -203,7 +203,7 @@ public class NarTestMojo
             dependency.isSnapshot();
 
             File libDirectory =
-                getLayout().getLibDirectory( getUnpackDirectory(), dependency.getArtifactId(), dependency.getVersion(),
+                getLayout().getLibDirectory( getUnpackDirectory(), dependency.getArtifactId(), dependency.getBaseVersion(),
                                              getAOL().toString(), Library.SHARED );
             sharedPaths.add( libDirectory );
         }

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -174,7 +174,7 @@ public class NarVcprojMojo extends AbstractCompileMojo {
                 File unpackDirectory = getUnpackDirectory();
                 File include =
                     getLayout().getIncludeDirectory( unpackDirectory, narDependency.getArtifactId(),
-                                                     narDependency.getVersion() );
+                                                     narDependency.getBaseVersion() );
                 getLog().debug("Looking for directory: " + include);
 				if (include.exists()) {
 					task.createIncludePath().setPath(include.getPath());
@@ -246,7 +246,7 @@ public class NarVcprojMojo extends AbstractCompileMojo {
                     File unpackDirectory = getUnpackDirectory();
                     File dir =
                         getLayout().getLibDirectory( unpackDirectory, dependency.getArtifactId(),
-                                                     dependency.getVersion(), aol.toString(), binding );
+                                                     dependency.getBaseVersion(), aol.toString(), binding );
 					getLog().debug("Looking for Library Directory: " + dir);
 					if (dir.exists()) {
 						LibrarySet libSet = new LibrarySet();


### PR DESCRIPTION
Use getBaseVersion() instead of getVersion() when constructing file paths for lib and include directories for nar dependencies. Otherwise Eclipse build configurations will break when a new snapshot of a
dependency is retrieved from a remote repo, because the file paths would have the new snapshot's timestamp in it.

Review is a must on this one. I know it works for me! But I may have made the change in some places where you wouldn't want it. I tried to make the change everywhere I saw that it was generating a file path.
