### PR TITLE
Support parameter "gnuConfigurePrepareSkip".

### DIFF
--- a/src/main/java/com/github/maven_nar/NarGnuConfigureMojo.java
+++ b/src/main/java/com/github/maven_nar/NarGnuConfigureMojo.java
@@ -36,6 +36,17 @@ import org.codehaus.plexus.util.FileUtils;
  * @author Mark Donszelmann
  */
 public class NarGnuConfigureMojo extends AbstractGnuMojo {
+
+	/**
+	 * If true, we run <code>./configure</code> in the source directory instead of copying the
+	 * source code to the <code>target/</code> directory first (this saves disk space but
+	 * violates Maven's paradigm of keeping generated files inside the  <code>target/</code>
+	 * directory structure.
+	 *
+	 * @parameter property="nar.gnu.configure.in-place" default-value="false"
+	 */
+	private boolean gnuConfigureInPlace;
+
 	/**
 	 * Skip running of autogen.sh (aka buildconf).
 	 * 
@@ -77,33 +88,41 @@ public class NarGnuConfigureMojo extends AbstractGnuMojo {
 			return;
 		}
 
-		File targetDir = getGnuAOLSourceDirectory();
-		if (getGnuSourceDirectory().exists()) {
-			getLog().info("Copying GNU sources");
+		File sourceDir = getGnuSourceDirectory();
+		if (sourceDir.exists()) {
+			File targetDir;
 
-			try {
-				FileUtils.mkdir(targetDir.getPath());
-				NarUtil.copyDirectoryStructure(getGnuSourceDirectory(),
-						targetDir, null, null);
-			} catch (IOException e) {
-				throw new MojoExecutionException("Failed to copy GNU sources",
+			if (!gnuConfigureInPlace) {
+				targetDir = getGnuAOLSourceDirectory();
+
+				getLog().info("Copying GNU sources");
+
+				try {
+					FileUtils.mkdir(targetDir.getPath());
+					NarUtil.copyDirectoryStructure(sourceDir,
+							targetDir, null, null);
+				} catch (IOException e) {
+					throw new MojoExecutionException("Failed to copy GNU sources",
 						e);
-			}
-
-			if (!gnuConfigureSkip && !gnuAutogenSkip) {
-				File autogen = new File(targetDir, AUTOGEN);
-				File buildconf = new File(targetDir, BUILDCONF);
-				if (autogen.exists()) {
-					getLog().info("Running GNU " + AUTOGEN);
-					runAutogen(autogen, targetDir, null);
-				} else if (buildconf.exists()) {
-					getLog().info("Running GNU " + BUILDCONF);
-					String gnuBuildconfArgsArray[] = null;
-					if (gnuBuildconfArgs != null) {
-						gnuBuildconfArgsArray = gnuBuildconfArgs.split("\\s");
-					}
-					runAutogen(buildconf, targetDir, gnuBuildconfArgsArray);
 				}
+
+				if (!gnuConfigureSkip && !gnuAutogenSkip) {
+					File autogen = new File(targetDir, AUTOGEN);
+					File buildconf = new File(targetDir, BUILDCONF);
+					if (autogen.exists()) {
+						getLog().info("Running GNU " + AUTOGEN);
+						runAutogen(autogen, targetDir, null);
+					} else if (buildconf.exists()) {
+						getLog().info("Running GNU " + BUILDCONF);
+						String gnuBuildconfArgsArray[] = null;
+						if (gnuBuildconfArgs != null) {
+							gnuBuildconfArgsArray = gnuBuildconfArgs.split("\\s");
+						}
+						runAutogen(buildconf, targetDir, gnuBuildconfArgsArray);
+					}
+				}
+			} else {
+				targetDir = sourceDir;
 			}
 
 			File configure = new File(targetDir, CONFIGURE);
@@ -126,12 +145,15 @@ public class NarGnuConfigureMojo extends AbstractGnuMojo {
 				}
 
 				// first 2 args are constant
-				args[0] = "./" + configure.getName();
+				args[0] = configure.getAbsolutePath();
 				args[1] = "--prefix="
 						+ getGnuAOLTargetDirectory().getAbsolutePath();
 
+				File buildDir = getGnuAOLSourceDirectory();
+				FileUtils.mkdir(buildDir.getPath());
+
 				getLog().info("args: " + arraysToString(args));
-				int result = NarUtil.runCommand("sh", args, targetDir, null,
+				int result = NarUtil.runCommand("sh", args, buildDir, null,
 						getLog());
 				if (result != 0) {
 					throw new MojoExecutionException("'" + CONFIGURE


### PR DESCRIPTION
Some source tree uses symbolic link.
But previous versions of Java doesn't API to create symlinks.
So it may causes strange behavior on the build stage. (refs #82)

GNU configure can build binaries on the different place from its source directory.
[like: "mkdir bin; cd bin; ../src/configure" ]
So in some cases, we don't need to copy.
But some source tree may have no configure but configure.ac.
In such cases, we should copy sources into target/gnu/*\* .

This patch provides parameter named "gnuConfigurePrepareSkip".
It has boolean value.
True means "not copy sources, not run autogen/buildconf."
The default is false. So it keeps the backward compatiblity.

gnuConfigurePrepareSkip has a good side-effect.
You can reduce your disk usage.
It may be remarkable if you build huge system like GCC.
