### PR TITLE
ARM support

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -560,6 +560,46 @@ amd64.Linux.gcc.jni.extension=so
 #amd64.Linux.gpp.arch.includes=lib/**/*.a lib/**/*.so
 
 #
+# ARM
+#
+arm.Linux.linker=g++
+
+# options for g++ compiler front end
+arm.Linux.gpp.cpp.compiler=g++
+arm.Linux.gpp.cpp.defines=ARM LINUX
+arm.Linux.gpp.cpp.options=-c -fPIC -pthread -fexceptions -O2 -fno-strict-aliasing -fno-omit-frame-pointer -Wall -Wextra
+arm.Linux.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+arm.Linux.gpp.cpp.excludes=
+
+arm.Linux.gpp.c.compiler=gcc
+arm.Linux.gpp.c.defines=ARM LINUX
+arm.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC
+arm.Linux.gpp.c.includes=**/*.c
+arm.Linux.gpp.c.excludes=
+
+# options for gcc linker front end
+arm.Linux.gpp.linker.options=-shared -shared-libgcc -fPIC -fexceptions
+arm.Linux.gpp.linker.sysLibs=stdc++
+arm.Linux.gpp.linker.libs=
+
+arm.Linux.gpp.java.include=include;include/linux
+arm.Linux.gpp.java.runtimeDirectory=jre/lib/i386/client
+
+arm.Linux.gpp.lib.prefix=lib
+arm.Linux.gpp.shared.prefix=lib
+arm.Linux.gpp.static.extension=a
+arm.Linux.gpp.shared.extension=so
+arm.Linux.gpp.plugin.extension=so
+arm.Linux.gpp.jni.extension=so
+arm.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+arm.Linux.gcc.static.extension=a
+arm.Linux.gcc.shared.extension=so*
+arm.Linux.gcc.plugin.extension=so
+arm.Linux.gcc.jni.extension=so
+
+#
 # MacOSX ("Mac OS X" => MacOSX) PowerPC
 #
 ppc.MacOSX.linker=g++


### PR DESCRIPTION
This PR adds initial ARM support. Please note that I'm not sure if the compiler/linker flags are OK - double check this. We use this patch in Fedora and it works well.
