### PR TITLE
Add support for handling the $RPM_OPT_FLAGS 

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -461,14 +461,34 @@ public abstract class Compiler
         optimization.setValue( optimize );
         compiler.setOptimize( optimization );
 
-        // add options
-        if ( options != null )
+        String rpmOptions = System.getenv( "RPM_OPT_FLAGS" );
+
+        if ( rpmOptions != null )
         {
-            for ( Iterator i = options.iterator(); i.hasNext(); )
+                // Make sure we won't add the default options later
+                // We want to use the options provided by RPM_OPT_FLAGS env variable
+                // *only*!
+                clearDefaultOptions = true;
+
+                String[] option = rpmOptions.replaceAll( "\\s+", " " ).split( " " );
+                for ( int i = 0; i < option.length; i++ )
+                {
+                    CompilerArgument arg = new CompilerArgument();
+                    arg.setValue( option[i] );
+                    compiler.addConfiguredCompilerArg( arg );
+                }
+        }
+        else
+        {
+            // add options
+            if ( options != null )
             {
-                CompilerArgument arg = new CompilerArgument();
-                arg.setValue( (String) i.next() );
-                compiler.addConfiguredCompilerArg( arg );
+                for ( Iterator i = options.iterator(); i.hasNext(); )
+                {
+                    CompilerArgument arg = new CompilerArgument();
+                    arg.setValue( (String) i.next() );
+                    compiler.addConfiguredCompilerArg( arg );
+                }
             }
         }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -392,6 +392,16 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
         }
         else
         {
+            // Try to find the executable in the $PATH
+            String paths = System.getenv("PATH");
+
+            for ( String path : paths.split(":") ) {
+                File command = new File( path, this.getCommand() );
+
+                if ( command.exists() ) {
+                    return command.getAbsolutePath();
+                }
+            }
             return this.getCommand();
         }
     }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineLinker.java
@@ -229,6 +229,16 @@ public abstract class CommandLineLinker extends AbstractLinker
         }
         else
         {
+            // Try to find the executable in the $PATH
+            String paths = System.getenv("PATH");
+
+            for ( String path : paths.split(":") ) {
+                File command = new File( path, this.getCommand() );
+
+                if ( command.exists() ) {
+                    return command.getAbsolutePath();
+                }
+            }
             return this.getCommand();
         }
     }


### PR DESCRIPTION
This PR adds support for handling the $RPM_OPT_FLAGS variable to set up the compilation arguments. This flag is used on RPM-based operating systems like Fedora or openSUSE to provide the most effective flags for selected architecture.
