### PR TITLE
Avoid addition of compiler's default options to the command line when the clearDefaultOptions tag is set to true.

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -513,6 +513,7 @@ public abstract class Compiler
             }
         }
 
+        compiler.setClearDefaultOptions(clearDefaultOptions);
         if ( !clearDefaultOptions )
         {
             String optionsProperty = NarProperties.getInstance(mojo.getMavenProject()).getProperty( getPrefix() + "options" );

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -54,8 +54,20 @@ public final class CompilerDef extends ProcessorDef {
 	private List order;
     private String toolPath;
 
+    private boolean clearDefaultOptions;
+
+
     public CompilerDef() {
     }
+
+    public boolean isClearDefaultOptions() {
+        return clearDefaultOptions;
+    }
+
+    public void setClearDefaultOptions(boolean clearDefaultOptions) {
+        this.clearDefaultOptions = clearDefaultOptions;
+    }
+
     /**
      * Adds a compiler command-line arg.
      */

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -274,16 +274,16 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
                 params.add(paramArray[j]);
             }
         }
-        paramArray = (ProcessorParam[]) (params
-                .toArray(new ProcessorParam[params.size()]));
-        boolean multithreaded = specificDef.getMultithreaded(defaultProviders,
-                1);
-        boolean debug = specificDef.getDebug(baseDefs, 0);
-        boolean exceptions = specificDef.getExceptions(defaultProviders, 1);
-        Boolean rtti = specificDef.getRtti(defaultProviders, 1);
-        OptimizationEnum optimization = specificDef.getOptimization(defaultProviders, 1);
-        this.addImpliedArgs(args, debug, multithreaded, exceptions, linkType, rtti, optimization);
+        paramArray = (ProcessorParam[]) (params.toArray(new ProcessorParam[params.size()]));
 
+        if (specificDef.isClearDefaultOptions() == false) {
+            boolean multithreaded = specificDef.getMultithreaded(defaultProviders, 1);
+            boolean debug = specificDef.getDebug(baseDefs, 0);
+            boolean exceptions = specificDef.getExceptions(defaultProviders, 1);
+            Boolean rtti = specificDef.getRtti(defaultProviders, 1);
+            OptimizationEnum optimization = specificDef.getOptimization(defaultProviders, 1);
+            this.addImpliedArgs(args, debug, multithreaded, exceptions, linkType, rtti, optimization);
+        }
 
         //
         //    add all appropriate defines and undefines


### PR DESCRIPTION
Using MVSC compiler, nar-=maven-plugin always adds compiler options even when the clearDefaultOptions is set to true. Nar-maven-plugin add automatically (for msvc compiler) the options \c \nologo \EHsc and may add others. I've made changes to prevent such behaviour, not only for MSVC compiler but for all the other compilers too. 
