### PR TITLE
Improve NarAssemblyMojo performance by skip copying older files

### DIFF
--- a/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
+++ b/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
@@ -84,7 +84,7 @@ public class NarAssemblyMojo
                 getLog().debug( "SrcDir: " + srcDir );
                 if ( srcDir.exists() )
                 {
-                    FileUtils.copyDirectoryStructure( srcDir, dstDir );
+                    FileUtils.copyDirectoryStructureIfModified( srcDir, dstDir );
                 }
             }
             catch ( IOException ioe )


### PR DESCRIPTION
Improve NarAssemblyMojo performance By calling org.codehaus.plexus.util.FileUtils.copyDirectoryStructureIfModified
to skip copying files with old timestamps.
