### PR TITLE
Fix NarTestCompileMojo to exclude executable dependency

### DIFF
--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -294,7 +294,7 @@ public class NarTestCompileMojo
             aol = dependency.getNarInfo().getAOL( getAOL() );
             getLog().debug( "Using Library AOL: " + aol.toString() );
 
-            if ( !binding.equals( Library.JNI ) && !binding.equals( Library.NONE ) )
+            if ( !binding.equals( Library.JNI ) && !binding.equals( Library.NONE ) && !binding.equals( Library.EXECUTABLE) )
             {
                 // check if it exists in the normal unpack directory 
                 File dir =


### PR DESCRIPTION
NarTestCompileMojo will be failed if dependent project is an executable. The fix
is simply by-passing the dependent executable projects. NarCompileMojo has the
same logic to filter executable projects.
