### PR TITLE
issue 105: remove invalid config element.

### DIFF
--- a/src/site/apt/faq.apt
+++ b/src/site/apt/faq.apt
@@ -24,9 +24,9 @@ would complicate matters.
 The JNI library is strictly connected to the corresponding java code in the
 main artifact (jar file). Since the main artifact has a version number, we decided
 that the JNI library should have the same version number. If you add the subtag
-<packageName> to the <library> tag, the nar-plugin will generate a NarSystem
+<narSystemPackage> to the <library> tag, the nar-plugin will generate a NarSystem
 class for you which will load the library. Assuming you specified com.mycompany.mypackage
-as packageName, then you need to add the following code to the class with the native
+as narSystemPackage, then you need to add the following code to the class with the native
 methods:
 
 +--

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -116,7 +116,7 @@ files are all stored in gnuTargetDirectory and will be handled in subsequent NAR
     This goal generates a NarSystem class if necessary. This class contains helper methods for your
 code to handle things at run-time. The static method "loadLibrary()" is currently the only method
 generated and will load your JNI library with name "artifactId-version". This goals only executed
-if you produce a JNI library and you specify a <packageName> as subtag of <library>. The NarSystem
+if you produce a JNI library and you specify a <narSystemPackage> as subtag of <library>. The NarSystem
 class will then end up in this package.
                                             
 * {nar-resources}

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -48,7 +48,7 @@ and link native code.
           <libraries>
             <library>
               <type>jni</type>
-              <packageName>com.mycompany.mypackage</packageName>
+              <narSystemPackage>com.mycompany.mypackage</narSystemPackage>
             </library>
           </libraries>
         </configuration>
@@ -119,7 +119,7 @@ The example also shows how to configure the
             </goals>
             <configuration>
               <cpp>true</cpp>
-              <packageName>org.domain.packagename</packageName>
+              <narSystemPackage>org.domain.packagename</narSystemPackage>
               <source>Module.swg</source>
             </configuration>
           </execution>


### PR DESCRIPTION
Fix example by removing invalid element.

The example on the usage page had an invalid element: `<packageName/>`.
