### PR TITLE
Add integration test demonstrating how to use a JNI NAR from a JAR

### DIFF
--- a/src/it/it0025-jar-dep-jni/pom.xml
+++ b/src/it/it0025-jar-dep-jni/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0025-jar-dep-jni</artifactId>
+  <packaging>jar</packaging>
+
+  <name>JAR Java Class Depends on JNI NAR</name>
+  <description>
+    Java class which depends on a separate JNI library
+  </description>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <id>nar-download</id>
+            <goals>
+              <goal>nar-download</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>nar-integration-test</id>
+            <goals>
+              <goal>nar-integration-test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0003-jni</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0025-jar-dep-jni/src/main/java/it0025/Hello.java
+++ b/src/it/it0025-jar-dep-jni/src/main/java/it0025/Hello.java
@@ -1,0 +1,30 @@
+package it0025;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import it0003.HelloWorldJNI;
+
+public class Hello
+{
+    public static int times(int x, int y)
+    {
+        return new HelloWorldJNI().timesHello(x, y);
+    }
+}

--- a/src/it/it0025-jar-dep-jni/src/test/java/it0025/HelloTest.java
+++ b/src/it/it0025-jar-dep-jni/src/test/java/it0025/HelloTest.java
@@ -1,0 +1,31 @@
+package it0025;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HelloTest
+{
+    @Test public final void testTimes()
+    {
+        Assert.assertEquals(42, Hello.times(3, 14));
+    }
+}

--- a/src/site/apt/examples.apt
+++ b/src/site/apt/examples.apt
@@ -22,7 +22,7 @@ directory.
 
 	[it0003-jni] A C routine called from Java.
 	
-	[it0004-java-dep-jni] A java project which depends on "jni". 
+	[it0004-java-dep-jni] A NAR JNI project which depends on "jni".
 
 	[it0005-jni-static] A C routine called from Java statically linked with the C-runtime library.
 	
@@ -79,6 +79,8 @@ directory.
 	
 	[it0021-executable-dep-lib-3rdparty] An executable dependent on the 3rd party library. 
 	
+	[it0025-jar-dep-jni] A JAR project which depends on "jni".
+
 	[] 
 
 	These examples are now all run as integration tests by running maven on the nar-maven-plugin from its top-level directory with the profile "run-its".


### PR DESCRIPTION
Like `it0004-java-dep-jni`, this test depends on `it0003-jni`; however, this test uses JAR packaging instead of NAR. `it0004` is left unchanged as it is also a JNI project that includes native code.

```
$ mvn -Prun-its
...
[INFO] Building: it0025-jar-dep-jni\pom.xml
[INFO] ..SUCCESS (5.4 s)
[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO]   Passed: 21, Failed: 0, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
```
