### PR TITLE
Upgrade maven-site-plugin to version 3.3 to fix broken "mvn site" on Maven 3.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.1</version>
+          <version>3.3</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Related issue: https://github.com/maven-nar/nar-maven-plugin/issues/108
