### PR TITLE
Document properties that the goals set.

### DIFF
--- a/src/site/apt/properties.apt
+++ b/src/site/apt/properties.apt
@@ -1,0 +1,27 @@
+	---
+NAR Plugin
+	---
+	---
+	---
+	
+Properties
+
+    The NAR plugin sets several properties that can be helpful in
+    configuring other plugins.
+    
+  * <<nar.arch>>: The architecture (e.g. x86_64).
+
+  * <<nar.os>>: The operating system (e.g. MacOSX).
+
+  * <<nar.linker>>: The linker (e.g. gpp).
+
+  * <<nar.aol>>: The full AOL string. This is helpful when setting
+<<<java.library.path>>>; with a default configuration, this would be
+<<<target/nar/$\{project.artifactId}-$\{project.version}-$\{nar.aol}/lib/$\{nar.aol}/jni>>>
+
+  * <<nar.aol.key>>: The AOL string with the '-' characters replaces by '.'
+    characters.
+
+  []
+
+

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -45,6 +45,7 @@ under the License.
       <item name="AOL Properties" href="aol.html"/>
       <item name="Examples" href="examples.html"/>
       <item name="Archetypes" href="archetypes.html"/>
+      <item name="Properties" href="properties.html"/>
       <item name="Compatibility" href="compatibility.html"/>
     </menu>
 


### PR DESCRIPTION
Add a new page to the maven-site-plugin documentation that lists the "nar.xxx" properties that the plugin sets in the project. These can be quite handy, in particular for setting up execution environments that need to set java.library.path.
