### PR TITLE
Update the plugin to a Maven 3.0.4 platform.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
     <skip.fortran.it>it0018-fortran/**</skip.fortran.it>
     <skip.toolchain.it>it0017-toolchain/**</skip.toolchain.it>
     <sonatypeOssDistMgmtSnapshotsUrl>https://oss.sonatype.org/content/repositories/snapshots/</sonatypeOssDistMgmtSnapshotsUrl>
+    <mavenPluginPluginVersion>3.2</mavenPluginPluginVersion>
   </properties>
 
   <prerequisites>
@@ -152,6 +153,14 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-component-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.bcel</groupId>
       <artifactId>bcel</artifactId>
       <version>5.2</version>
@@ -192,6 +201,14 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>${mavenPluginPluginVersion}</version>
+          <configuration>
+            <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
           <version>2.5</version>
         </plugin>
@@ -207,6 +224,17 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-descriptor</id>
+            <goals>
+              <goal>descriptor</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -518,7 +546,7 @@
                       <pluginExecutionFilter>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-plugin-plugin</artifactId>
-                        <versionRange>3.1</versionRange>
+                        <versionRange>3.2</versionRange>
                         <goals>
                           <goal>descriptor</goal>
                           <goal>helpmojo</goal>

--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.Project;
 
 /**
@@ -35,114 +36,96 @@ public abstract class AbstractCompileMojo
 
     /**
      * C++ Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Cpp cpp;
 
     /**
      * C Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private C c;
 
     /**
      * Fortran Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Fortran fortran;
 
     /**
      * Resource Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Resource resource;
 
     /**
      * IDL Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private IDL idl;
 
     /**
      * Message Compiler
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Message message;
 
     /**
      * By default NAR compile will attempt to compile using all known compilers against files in the directories specified by convention.
      * This allows configuration to a reduced set, you will have to specify each compiler to use in the configuration.
-     * 
-     * @parameter default-value="false"
      */
+    @Parameter(defaultValue = "false")
     protected boolean onlySpecifiedCompilers;
 
     /**
      * Do we log commands that is executed to produce the end-result?
      * Conception was to allow eclipse to sniff out include-paths from compile.
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     protected int commandLogLevel=Project.MSG_VERBOSE;
 
     /**
      * Maximum number of Cores/CPU's to use. 0 means unlimited.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private int maxCores = 0;
 
 
     /**
      * Fail on compilation/linking error.
-     * 
-     * @parameter default-value="true"
-     * @required
      */
+    @Parameter(defaultValue = "true", required = true)
     private boolean failOnError;
 
     /**
      * Sets the type of runtime library, possible values "dynamic", "static".
-     * 
-     * @parameter default-value="dynamic"
-     * @required
      */
+    @Parameter(defaultValue = "dynamic", required = true)
     private String runtime;
 
     /**
      * Set use of libtool. If set to true, the "libtool " will be prepended to the command line for compatible
      * processors.
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(defaultValue = "false", required = true)
     private boolean libtool;
 
     /**
      * List of tests to create
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List tests;
 
     /**
      * Java info for includes and linking
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Java java;
 
     /**
      * Flag to cpptasks to indicate whether linker options should be decorated or not
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     protected boolean decorateLinkerOptions;
 
     private List/* <String> */dependencyLibOrder;

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -32,6 +32,8 @@ import org.apache.maven.artifact.resolver.ArtifactResolver;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 
 /**
@@ -39,45 +41,33 @@ import org.codehaus.plexus.archiver.manager.ArchiverManager;
  */
 public abstract class AbstractDependencyMojo extends AbstractNarMojo {
 
-	/**
-	 * @parameter default-value="${localRepository}"
-	 * @required
-	 * @readonly
-	 */
+    @Parameter(defaultValue = "${localRepository}", required = true, readonly = true)
 	private ArtifactRepository localRepository;
 
 	/**
 	 * Artifact resolver, needed to download the attached nar files.
-	 * 
-	 * @component role="org.apache.maven.artifact.resolver.ArtifactResolver"
-	 * @required
-	 * @readonly
 	 */
+    @Component(role = org.apache.maven.artifact.resolver.ArtifactResolver.class)
 	protected ArtifactResolver artifactResolver;
 
 	/**
 	 * Remote repositories which will be searched for nar attachments.
-	 * 
-	 * @parameter default-value="${project.remoteArtifactRepositories}"
-	 * @required
-	 * @readonly
 	 */
+    @Parameter(defaultValue = "${project.remoteArtifactRepositories}", required = true, readonly = true)
 	protected List remoteArtifactRepositories;
 
     /**
      * To look up Archiver/UnArchiver implementations
-     * 
-     * @component role="org.codehaus.plexus.archiver.manager.ArchiverManager"
-     * @required
      */
+    @Component(role = org.codehaus.plexus.archiver.manager.ArchiverManager.class)
     protected ArchiverManager archiverManager;
 
 	/**
      * The plugin remote repositories declared in the pom.
      * 
-     * @parameter default-value="${project.pluginArtifactRepositories}"
      * @since 2.2
      */
+    //@Parameter(defaultValue = "${project.pluginArtifactRepositories}")
     // private List remotePluginRepositories;
 
 	protected final ArtifactRepository getLocalRepository() {

--- a/src/main/java/com/github/maven_nar/AbstractGnuMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractGnuMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Abstract GNU Mojo keeps configuration
@@ -34,26 +35,20 @@ public abstract class AbstractGnuMojo
 {
     /**
      * Use GNU goals on Windows
-     * 
-     * @parameter expresssion="nar.gnu.useonwindows" default-value="false"
-     * @required
      */
+    @Parameter(defaultValue = "nar.gnu.useonwindows", required = true)
     private boolean gnuUseOnWindows;
     
     /**
      * Source directory for GNU style project
-     * 
-     * @parameter default-value="${basedir}/src/gnu"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/gnu")
     private File gnuSourceDirectory;
 
     /**
      * Directory in which gnu sources are copied and "configured"
-     * 
-     * @parameter default-value="${project.build.directory}/nar/gnu"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}/nar/gnu")
     private File gnuTargetDirectory;
 
     /**

--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -28,6 +28,8 @@ import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -40,65 +42,54 @@ public abstract class AbstractNarMojo
 
     /**
      * Skip running of NAR plugins (any) altogether.
-     * 
-     * @parameter property="nar.skip" default-value="false"
      */
+    @Parameter(property = "nar.skip", defaultValue = "false")
     private boolean skip;
 
     /**
      * Skip the tests. Listens to Maven's general 'maven.skip.test'.
-     * 
-     * @parameter property="maven.test.skip"
      */
+    @Parameter(property = "maven.test.skip")
     boolean skipTests;
 
     /**
      * Ignore errors and failures.
-     * 
-     * @parameter property="nar.ignore" default-value="false"
      */
+    @Parameter(property = "nar.ignore", defaultValue = "false")
     private boolean ignore;
 
     /**
      * The Architecture for the nar, Some choices are: "x86", "i386", "amd64", "ppc", "sparc", ... Defaults to a derived
      * value from ${os.arch}
-     * 
-     * @parameter property="nar.arch"
      */
+    @Parameter(property = "nar.arch")
     private String architecture;
 
     /**
      * The Operating System for the nar. Some choices are: "Windows", "Linux", "MacOSX", "SunOS", ... Defaults to a
      * derived value from ${os.name} FIXME table missing
-     * 
-     * @parameter property="nar.os"
      */
+    @Parameter(property = "nar.os")
     private String os;
 
     /**
      * Architecture-OS-Linker name. Defaults to: arch-os-linker.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter(defaultValue = "")
     private String aol;
 
     /**
      * Linker
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Linker linker;
 
-    /**
-     * @parameter property="project.build.directory"
-     * @readonly
-     */
+    // these could be obtained from an injected project model.
+
+    @Parameter(property = "project.build.directory", readonly = true)
     private File outputDirectory;
 
-    /**
-     * @parameter property="project.build.outputDirectory"
-     * @readonly
-     */
+    @Parameter(property = "project.build.outputDirectory", readonly = true)
     protected File classesDirectory;
 
     /**
@@ -108,75 +99,60 @@ public abstract class AbstractNarMojo
      *  - for exe default-value="${project.artifactId}"
      *  -- for tests default-value="${test.name}"
      * 
-     * @parameter 
      */
+    @Parameter
     private String output;
 
-    /**
-     * @parameter property="project.basedir"
-     * @readonly
-     */
+    @Parameter(property = "project.basedir", readonly = true)
     private File baseDir;
 
     /**
      * Target directory for Nar file construction. Defaults to "${project.build.directory}/nar" for "nar-compile" goal
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private File targetDirectory;
 
     /**
      * Target directory for Nar test construction. Defaults to "${project.build.directory}/test-nar" for "nar-testCompile" goal
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private File testTargetDirectory;
 
     /**
      * Target directory for Nar file unpacking. Defaults to "${targetDirectory}"
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private File unpackDirectory;
 
     /**
      * Target directory for Nar test unpacking. Defaults to "${testTargetDirectory}"
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private File testUnpackDirectory;
 
     /**
      * List of classifiers which you want download/unpack/assemble 
      * Example ppc-MacOSX-g++, x86-Windows-msvc, i386-Linux-g++.
      * Not setting means all.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     protected List<String> classifiers;
 
     /**
      * List of libraries to create
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     protected List<Library> libraries;
 
     /**
      * Layout to be used for building and unpacking artifacts
-     * 
-     * @parameter property="nar.layout" default-value="com.github.maven_nar.NarLayout21"
-     * @required
      */
+    @Parameter(property = "nar.layout", defaultValue = "com.github.maven_nar.NarLayout21", required = true)
     private String layout;
 
     private NarLayout narLayout;
 
-    /**
-     * @parameter property="project"
-     * @readonly
-     * @required
-     */
+   @Component
     private MavenProject mavenProject;
 
     private AOL aolId;
@@ -185,17 +161,14 @@ public abstract class AbstractNarMojo
 
     /**
      * Javah info
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private Javah javah;
 
     /**
      * The home of the Java system. Defaults to a derived value from ${java.home} which is OS specific.
-     * 
-     * @parameter default-value=""
-     * @readonly
      */
+    @Parameter(readonly = true)
     private File javaHome;
 
     protected final void validate()

--- a/src/main/java/com/github/maven_nar/AbstractResourcesMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractResourcesMojo.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.archiver.ArchiverException;
 import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
@@ -42,34 +44,26 @@ public abstract class AbstractResourcesMojo
 {
     /**
      * Binary directory
-     * 
-     * @parameter default-value="bin"
-     * @required
      */
+    @Parameter(defaultValue = "bin", required = true)
     private String resourceBinDir;
 
     /**
      * Include directory
-     * 
-     * @parameter default-value="include"
-     * @required
      */
+    @Parameter(defaultValue = "include", required = true)
     private String resourceIncludeDir;
 
     /**
      * Library directory
-     * 
-     * @parameter default-value="lib"
-     * @required
      */
+    @Parameter(defaultValue = "lib", required = true)
     private String resourceLibDir;
 
     /**
      * To look up Archiver/UnArchiver implementations
-     * 
-     * @component role="org.codehaus.plexus.archiver.manager.ArchiverManager"
-     * @required
      */
+    @Component(role = org.codehaus.plexus.archiver.manager.ArchiverManager.class)
     private ArchiverManager archiverManager;
 
     protected final int copyIncludes( File srcDir )

--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -39,6 +39,7 @@ import com.github.maven_nar.cpptasks.types.DefineSet;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -53,208 +54,168 @@ public abstract class Compiler
     /**
      * The name of the compiler. Some choices are: "msvc", "g++", "gcc", "CC", "cc", "icc", "icpc", ... Default is
      * Architecture-OS-Linker specific: FIXME: table missing
-     * 
-     * @parameter default-value=""
+
      */
+    @Parameter
     private String name;
 
     /**
      * Path location of the compile tool
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     private String toolPath;
 
     /**
      * Source directory for native files
-     * 
-     * @parameter default-value="${basedir}/src/main"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/main", required = true)
     private File sourceDirectory;
 
     /**
      * Source directory for native test files
-     * 
-     * @parameter default-value="${basedir}/src/test"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/test", required = true)
     private File testSourceDirectory;
 
     /**
      * Include patterns for sources
-     * 
-     * @parameter default-value=""
-     * @required
      */
+    @Parameter(required = true)
     private Set includes = new HashSet();
 
     /**
      * Exclude patterns for sources
-     * 
-     * @parameter default-value=""
-     * @required
      */
+    @Parameter(required = true)
     private Set excludes = new HashSet();
 
     /**
      * Include patterns for test sources
-     * 
-     * @parameter default-value=""
-     * @required
      */
+    @Parameter(required = true)
     private Set testIncludes = new HashSet();
 
     /**
      * Exclude patterns for test sources
-     * 
-     * @parameter default-value=""
-     * @required
      */
+    @Parameter(required = true)
     private Set testExcludes = new HashSet();
 
     /**
      * Compile with debug information.
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean debug = false;
 
     /**
      * Enables generation of exception handling code.
-     * 
-     * @parameter default-value="true"
-     * @required
      */
+    @Parameter(defaultValue = "true", required = true)
     private boolean exceptions = true;
 
     /**
      * Enables run-time type information.
-     * 
-     * @parameter default-value="true"
-     * @required
      */
+    @Parameter(defaultValue = "true", required = true)
     private boolean rtti = true;
 
     /**
      * Sets optimization. Possible choices are: "none", "size", "minimal", "speed", "full", "aggressive", "extreme",
      * "unsafe".
-     * 
-     * @parameter default-value="none"
-     * @required
      */
+    @Parameter(defaultValue = "none", required = true)
     private String optimize = "none";
 
     /**
      * Enables or disables generation of multi-threaded code. Default value: false, except on Windows.
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean multiThreaded = false;
 
     /**
      * Defines
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List defines;
 
     /**
      * Defines for the compiler as a comma separated list of name[=value] pairs, where the value is optional. Will work
      * in combination with &lt;defines&gt;.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String defineSet;
 
     /**
      * Clears default defines
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean clearDefaultDefines;
 
     /**
      * Undefines
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List undefines;
 
     /**
      * Undefines for the compiler as a comma separated list of name[=value] pairs where the value is optional. Will work
      * in combination with &lt;undefines&gt;.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String undefineSet;
 
     /**
      * Clears default undefines
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter
     private boolean clearDefaultUndefines;
 
     /**
      * Include Paths. Defaults to "${sourceDirectory}/include"
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List includePaths;
 
     /**
      * Test Include Paths. Defaults to "${testSourceDirectory}/include"
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List testIncludePaths;
 
     /**
      * System Include Paths, which are added at the end of all include paths
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List systemIncludePaths;
 
     /**
      * Additional options for the C++ compiler Defaults to Architecture-OS-Linker specific values. FIXME table missing
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List options;
 
     /**
      * Additional options for the compiler when running in the nar-testCompile phase.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List testOptions;
 
     /**
      * Options for the compiler as a whitespace separated list. Will work in combination with &lt;options&gt;.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String optionSet;
 
     /**
      * Clears default options
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean clearDefaultOptions;
 
     /**
      * Comma separated list of filenames to compile in order
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String compileOrder;
 
     private AbstractCompileMojo mojo;

--- a/src/main/java/com/github/maven_nar/Java.java
+++ b/src/main/java/com/github/maven_nar/Java.java
@@ -31,6 +31,7 @@ import com.github.maven_nar.cpptasks.types.LinkerArgument;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Java specifications for NAR
@@ -42,41 +43,34 @@ public class Java
 
     /**
      * Add Java includes to includepath
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean include = false;
 
     /**
      * Java Include Paths, relative to a derived ${java.home}. Defaults to: "${java.home}/include" and
      * "${java.home}/include/<i>os-specific</i>".
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List includePaths;
 
     /**
      * Add Java Runtime to linker
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean link = false;
 
     /**
      * Relative path from derived ${java.home} to the java runtime to link with Defaults to Architecture-OS-Linker
      * specific value. FIXME table missing
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String runtimeDirectory;
 
     /**
      * Name of the runtime
-     * 
-     * @parameter default-value="jvm"
      */
+    @Parameter(defaultValue = "jvm")
     private String runtime = "jvm";
 
     private AbstractCompileMojo mojo;

--- a/src/main/java/com/github/maven_nar/Javah.java
+++ b/src/main/java/com/github/maven_nar/Javah.java
@@ -34,6 +34,7 @@ import org.apache.bcel.classfile.Method;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.codehaus.plexus.compiler.util.scan.InclusionScanException;
@@ -54,82 +55,68 @@ public class Javah
 
     /**
      * Javah command to run.
-     * 
-     * @parameter default-value="javah"
      */
+    @Parameter(defaultValue = "javah")
     private String name = "javah";
 
     /**
      * Add boot class paths. By default none.
-     * 
-     * @parameter
      */
+    @Parameter
     private List/* <File> */bootClassPaths = new ArrayList();
 
     /**
      * Add class paths. By default the classDirectory directory is included and all dependent classes.
-     * 
-     * @parameter
      */
+    @Parameter
     private List/* <File> */classPaths = new ArrayList();
 
     /**
      * The target directory into which to generate the output.
-     * 
-     * @parameter default-value="${project.build.directory}/nar/javah-include"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}/nar/javah-include", required = true)
     private File jniDirectory;
 
     /**
      * The class directory to scan for class files with native interfaces.
-     * 
-     * @parameter default-value="${project.build.directory}/classes"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.directory}/classes", required = true)
     private File classDirectory;
 
     /**
      * The set of files/patterns to include Defaults to "**\/*.class"
-     * 
-     * @parameter
      */
+    @Parameter
     private Set includes = new HashSet();
 
     /**
      * A list of exclusion filters.
-     * 
-     * @parameter
      */
+    @Parameter
     private Set excludes = new HashSet();
 
     /**
      * A list of class names e.g. from java.sql.* that are also passed to javah.
-     *
-     * @parameter
      */
+    @Parameter
     private Set extraClasses = new HashSet();
 
     /**
      * The granularity in milliseconds of the last modification date for testing whether a source needs recompilation
-     * 
-     * @parameter default-value="0"
-     * @required
      */
+    @Parameter(defaultValue = "0", required = true)
     private int staleMillis = 0;
 
     /**
      * The directory to store the timestampfile for the processed aid files. Defaults to jniDirectory.
-     * 
-     * @parameter
      */
+    @Parameter
     private File timestampDirectory;
 
     /**
      * The timestampfile for the processed class files. Defaults to name of javah.
-     * 
-     * @parameter
      */
+    @Parameter
     private File timestampFile;
 
     private AbstractNarMojo mojo;

--- a/src/main/java/com/github/maven_nar/Lib.java
+++ b/src/main/java/com/github/maven_nar/Lib.java
@@ -31,6 +31,7 @@ import com.github.maven_nar.cpptasks.types.LibraryTypeEnum;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.Project;
 
 /**
@@ -43,33 +44,26 @@ public class Lib
 
 	/**
      * Name of the library, or a dependency groupId:artifactId if this library contains sublibraries
-	 * 
-	 * @parameter default-value=""
-	 * @required
 	 */
+    @Parameter(required = true)
 	private String name;
 
 	/**
 	 * Type of linking for this library
-	 * 
-	 * @parameter default-value="shared"
-	 * @required
 	 */
+    @Parameter(defaultValue = "shared", required = true)
 	private String type = Library.SHARED;
 
 	/**
 	 * Location for this library
-	 * 
-	 * @parameter default-value=""
-	 * @required
 	 */
+    @Parameter(required = true)
 	private File directory;
 
 	/**
 	 * Sub libraries for this library
-	 * 
-	 * @parameter default-value=""
 	 */
+    @Parameter
 	private List/* <Lib> */libs;
 
     public final void addLibSet( AbstractDependencyMojo mojo, LinkerDef linker, Project antProject )

--- a/src/main/java/com/github/maven_nar/Library.java
+++ b/src/main/java/com/github/maven_nar/Library.java
@@ -22,6 +22,8 @@ package com.github.maven_nar;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.plugins.annotations.Parameter;
+
 /**
  * Sets up a library to create
  * 
@@ -46,75 +48,63 @@ public class Library
     /**
      * Type of the library to generate. Possible choices are: "plugin", "shared", "static", "jni" or "executable".
      * Defaults to "shared".
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String type = SHARED;
     
     /**
      * Type of subsystem to generate: "gui", "console", "other". Defaults to "console".
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     private String subSystem = "console";
     
     /**
      * Link with stdcpp if necessary Defaults to true.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter(defaultValue = "true")
     private boolean linkCPP = true;
 
     /**
      * Link with fortran runtime if necessary Defaults to false.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private boolean linkFortran = false;
 
     /**
      * Link with fortran startup, so that the gcc linker can find the "main" of fortran. Defaults to false.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private boolean linkFortranMain = false;
 
     /**
      * If specified will create the NarSystem class with methods to load a JNI library.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String narSystemPackage = null;
 
     /**
      * Name of the NarSystem class
-     * 
-     * @parameter default-value="NarSystem"
-     * @required
      */
+    @Parameter(defaultValue = "NarSystem", required = true)
     private String narSystemName = "NarSystem";
 
     /**
      * The target directory into which to generate the output.
-     * 
-     * @parameter default-value="${project.build.dir}/nar/nar-generated"
-     * @required
      */
+    @Parameter(defaultValue = "${project.build.dir}/nar/nar-generated", required = true)
     private String narSystemDirectory = "nar-generated";
 
     /**
      * When true and if type is "executable" run this executable. Defaults to false;
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private boolean run = false;
 
     /**
      * Arguments to be used for running this executable. Defaults to empty list. This option is only used if run=true
      * and type=executable.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List/* <String> */args = new ArrayList();
 
     public final String getType()

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -39,6 +39,7 @@ import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.Project;
 import org.codehaus.plexus.util.FileUtils;
 
@@ -55,92 +56,78 @@ public class Linker
     /**
      * The Linker Some choices are: "msvc", "g++", "CC", "icpc", ... Default is Architecture-OS-Linker specific: FIXME:
      * table missing
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String name;
 
     /**
      * Path location of the linker tool
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     private String toolPath;
 
     /**
      * Enables or disables incremental linking.
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean incremental = false;
 
     /**
      * Enables or disables the production of a map file.
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean map = false;
 
     /**
      * Options for the linker Defaults to Architecture-OS-Linker specific values. FIXME table missing
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List options;
 
     /**
      * Additional options for the linker when running in the nar-testCompile phase.
      * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List testOptions;
 
     /**
      * Options for the linker as a whitespace separated list. Defaults to Architecture-OS-Linker specific values. Will
      * work in combination with &lt;options&gt;.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String optionSet;
 
     /**
      * Clears default options
-     * 
-     * @parameter default-value="false"
-     * @required
      */
+    @Parameter(required = true)
     private boolean clearDefaultOptions;
 
     /**
      * Adds libraries to the linker.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List/* <Lib> */libs;
 
     /**
      * Adds libraries to the linker. Will work in combination with &lt;libs&gt;. The format is comma separated,
      * colon-delimited values (name:type:dir), like "myLib:shared:/home/me/libs/, otherLib:static:/some/path".
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String libSet;
 
     /**
      * Adds system libraries to the linker.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List/* <SysLib> */sysLibs;
 
     /**
      * Adds system libraries to the linker. Will work in combination with &lt;sysLibs&gt;. The format is comma
      * separated, colon-delimited values (name:type), like "dl:shared, pthread:shared".
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String sysLibSet;
 
     /**
@@ -151,9 +138,8 @@ public class Linker
      * <p>
      * Example: &lt;narDependencyLibOrder&gt;someGroup:myProduct, other.group:productB&lt;narDependencyLibOrder&gt;
      * </p>
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String narDependencyLibOrder;
 
     private final Log log;

--- a/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
+++ b/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
@@ -27,17 +27,16 @@ import java.util.List;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
  * Assemble libraries of NAR files.
- * 
- * @goal nar-assembly
- * @phase process-resources
- * @requiresProject
- * @requiresDependencyResolution compile
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-assembly", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarAssemblyMojo
     extends AbstractDependencyMojo
 {

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -41,6 +41,10 @@ import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.codehaus.plexus.util.FileUtils;
@@ -49,23 +53,17 @@ import org.codehaus.plexus.util.StringUtils;
 /**
  * Compiles native source files.
  * 
- * @goal nar-compile
- * @phase compile
  * @requiresSession
- * @requiresProject
- * @requiresDependencyResolution compile
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-compile", defaultPhase = LifecyclePhase.COMPILE, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarCompileMojo
     extends AbstractCompileMojo
 {
     /**
      * The current build session instance.
-     * 
-     * @parameter default-value="${session}"
-     * @required
-     * @readonly
      */
+    @Component
     protected MavenSession session;
 
     @Override

--- a/src/main/java/com/github/maven_nar/NarDownloadDependenciesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarDownloadDependenciesMojo.java
@@ -21,15 +21,16 @@ package com.github.maven_nar;
 
 import java.util.List;
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 /**
  * Downloads any dependent NAR files. This includes the noarch and aol type NAR files.
  * 
- * @goal nar-download-dependencies
- * @phase process-sources
- * @requiresProject
- * @requiresDependencyResolution test
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-download-dependencies", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class NarDownloadDependenciesMojo
     extends AbstractDependencyMojo
 {

--- a/src/main/java/com/github/maven_nar/NarDownloadMojo.java
+++ b/src/main/java/com/github/maven_nar/NarDownloadMojo.java
@@ -20,15 +20,16 @@ package com.github.maven_nar;
  */
 
 
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
 /**
  * Downloads and unpacks any dependent NAR files. This includes the noarch and aol type NAR files.
  * 
- * @goal nar-download
- * @phase process-sources
- * @requiresProject
- * @requiresDependencyResolution compile
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-download", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarDownloadMojo
     extends AbstractDependencyMojo
 {

--- a/src/main/java/com/github/maven_nar/NarGnuConfigureMojo.java
+++ b/src/main/java/com/github/maven_nar/NarGnuConfigureMojo.java
@@ -24,17 +24,17 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.FileUtils;
 
 /**
  * Copies the GNU style source files to a target area, autogens and configures
  * them.
- * 
- * @goal nar-gnu-configure
- * @phase process-sources
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-gnu-configure", requiresProject = true, defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class NarGnuConfigureMojo extends AbstractGnuMojo {
 
 	/**
@@ -42,37 +42,32 @@ public class NarGnuConfigureMojo extends AbstractGnuMojo {
 	 * source code to the <code>target/</code> directory first (this saves disk space but
 	 * violates Maven's paradigm of keeping generated files inside the  <code>target/</code>
 	 * directory structure.
-	 *
-	 * @parameter property="nar.gnu.configure.in-place" default-value="false"
 	 */
+    @Parameter(property = "nar.gnu.configure.in-place")
 	private boolean gnuConfigureInPlace;
 
 	/**
 	 * Skip running of autogen.sh (aka buildconf).
-	 * 
-	 * @parameter property="nar.gnu.autogen.skip" default-value="false"
 	 */
+    @Parameter(property = "nar.gnu.autogen.skip")
 	private boolean gnuAutogenSkip;
 
 	/**
 	 * Skip running of configure and therefore also autogen.sh
-	 * 
-	 * @parameter property="nar.gnu.configure.skip" default-value="false"
 	 */
+    @Parameter(property = "nar.gnu.configure.skip")
 	private boolean gnuConfigureSkip;
 
 	/**
 	 * Arguments to pass to GNU configure.
-	 * 
-	 * @parameter property="nar.gnu.configure.args" default-value=""
 	 */
+    @Parameter(property = "nar.gnu.configure.args", defaultValue = "")
 	private String gnuConfigureArgs;
 
 	/**
 	 * Arguments to pass to GNU buildconf.
-	 * 
-	 * @parameter property="nar.gnu.buildconf.args" default-value=""
 	 */
+    @Parameter(property = "nar.gnu.buildconf.args", defaultValue = "")
 	private String gnuBuildconfArgs;
 
 	private static final String AUTOGEN = "autogen.sh";
@@ -81,7 +76,10 @@ public class NarGnuConfigureMojo extends AbstractGnuMojo {
 
 	private static final String CONFIGURE = "configure";
 
-	public final void narExecute() throws MojoExecutionException,
+    public NarGnuConfigureMojo() {
+    }
+
+    public final void narExecute() throws MojoExecutionException,
 			MojoFailureException {
 
 		if (!useGnu()) {

--- a/src/main/java/com/github/maven_nar/NarGnuMakeMojo.java
+++ b/src/main/java/com/github/maven_nar/NarGnuMakeMojo.java
@@ -23,37 +23,34 @@ import java.io.File;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Runs make on the GNU style generated Makefile
- * 
- * @goal nar-gnu-make
- * @phase compile
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-gnu-make", requiresProject = true, defaultPhase = LifecyclePhase.COMPILE)
 public class NarGnuMakeMojo
     extends AbstractGnuMojo
 {
     /**
      * Space delimited list of arguments to pass to make
-     *
-     * @parameter default-value=""
      */
+    @Parameter(defaultValue = "")
     private String gnuMakeArgs;
 
     /**
      * Comma delimited list of environment variables to setup before running make
-     *
-     * @parameter default-value=""
      */
+    @Parameter(defaultValue = "")
     private String gnuMakeEnv;
 
     /**
      * Boolean to control if we should skip 'make install' after the make
-     *
-     * @parameter default-value="false"
      */
+    @Parameter
     private boolean gnuMakeInstallSkip;
 
     public final void narExecute()

--- a/src/main/java/com/github/maven_nar/NarGnuProcess.java
+++ b/src/main/java/com/github/maven_nar/NarGnuProcess.java
@@ -23,15 +23,14 @@ import java.io.File;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Move the GNU style output in the correct directories for nar-package
- * 
- * @goal nar-gnu-process
- * @phase process-classes
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-gnu-process", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresProject = true)
 public class NarGnuProcess
     extends AbstractGnuMojo
 {

--- a/src/main/java/com/github/maven_nar/NarGnuResources.java
+++ b/src/main/java/com/github/maven_nar/NarGnuResources.java
@@ -23,15 +23,14 @@ import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Move the GNU style include/lib to some output directory
- * 
- * @goal nar-gnu-resources
- * @phase process-resources
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-gnu-resources", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true)
 public class NarGnuResources
     extends AbstractGnuMojo
 {

--- a/src/main/java/com/github/maven_nar/NarJavahMojo.java
+++ b/src/main/java/com/github/maven_nar/NarJavahMojo.java
@@ -22,33 +22,27 @@ package com.github.maven_nar;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.toolchain.ToolchainManager;
 
 /**
  * Compiles class files into c/c++ headers using "javah". Any class file that contains methods that were declared
  * "native" will be run through javah.
  * 
- * @goal nar-javah
- * @phase compile
  * @requiresSession
- * @requiresDependencyResolution compile
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-javah", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarJavahMojo
     extends AbstractNarMojo
 {
-    /**
-     * @component
-     */
+    @Component
     private ToolchainManager toolchainManager;
 
-    /**
-     * The current build session instance.
-     * 
-     * @parameter default-value="${session}"
-     * @required
-     * @readonly
-     */
+    @Component
     private MavenSession session;
     
     protected final ToolchainManager getToolchainManager() {

--- a/src/main/java/com/github/maven_nar/NarPackageMojo.java
+++ b/src/main/java/com/github/maven_nar/NarPackageMojo.java
@@ -21,33 +21,32 @@ package com.github.maven_nar;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProjectHelper;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 
 /**
  * Jar up the NAR files and attach them to the projects main artifact (for installation and deployment).
  * 
- * @goal nar-package
- * @phase package
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-package", defaultPhase = LifecyclePhase.PACKAGE, requiresProject = true)
 public class NarPackageMojo
     extends AbstractNarMojo
 {    
     /**
      * To look up Archiver/UnArchiver implementations
-     * 
-     * @component role="org.codehaus.plexus.archiver.manager.ArchiverManager"
-     * @required
      */
+    @Component(role = org.codehaus.plexus.archiver.manager.ArchiverManager.class)
     private ArchiverManager archiverManager;
     
     /**
      * Used for attaching the artifact in the project
-     * 
-     * @component
      */
+    @Component
     private MavenProjectHelper projectHelper;
 
 

--- a/src/main/java/com/github/maven_nar/NarPreparePackageMojo.java
+++ b/src/main/java/com/github/maven_nar/NarPreparePackageMojo.java
@@ -21,15 +21,14 @@ package com.github.maven_nar;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Create the nar.properties file.
- * 
- * @goal nar-prepare-package
- * @phase prepare-package
- * @requiresProject
  * @author GDomjan
  */
+@Mojo(name = "nar-prepare-package", defaultPhase = LifecyclePhase.PREPARE_PACKAGE, requiresProject = true)
 public class NarPreparePackageMojo
     extends AbstractNarMojo
 {    

--- a/src/main/java/com/github/maven_nar/NarProcessLibraries.java
+++ b/src/main/java/com/github/maven_nar/NarProcessLibraries.java
@@ -10,25 +10,24 @@ import java.util.List;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Adds the ability to run arbitrary command line tools to post-process the
  * compiled output (ie: ranlib/ar/etc)
  *
  * @author Richard Kerr
- * @goal nar-process-libraries
- * @phase process-classes
- * @requiresSession
- * @requiresProject
- * @author Richard Kerr
+  * @author Richard Kerr
  */
+@Mojo(name = "nar-process-libraries", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresProject = true)
 public class NarProcessLibraries extends AbstractCompileMojo {
 
     /**
      * List of commands to execute
-     *
-     * @parameter default-value=""
      */
+    @Parameter
     private List<ProcessLibraryCommand> commands;
 
     private Log log = getLog();

--- a/src/main/java/com/github/maven_nar/NarResourcesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarResourcesMojo.java
@@ -25,34 +25,30 @@ import java.util.Iterator;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.SelectorUtils;
 
 /**
  * Copies any resources, including AOL specific distributions, to the target area for packaging
- * 
- * @goal nar-resources
- * @phase process-resources
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-resources", defaultPhase = LifecyclePhase.PROCESS_RESOURCES, requiresProject = true)
 public class NarResourcesMojo
     extends AbstractResourcesMojo
 {
     /**
      * Use given AOL only. If false, copy for all available AOLs.
-     * 
-     * @parameter property="nar.resources.copy.aol" default-value="true"
-     * @required
      */
+    @Parameter(property = "nar.resources.copy.aol", defaultValue = "true", required = true)
     private boolean resourcesCopyAOL;
 
     /**
      * Directory for nar resources. Defaults to src/nar/resources
-     * 
-     * @parameter default-value="${basedir}/src/nar/resources"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/nar/resources", required = true)
     private File resourceDirectory;
 
     public final void narExecute()

--- a/src/main/java/com/github/maven_nar/NarSystemMojo.java
+++ b/src/main/java/com/github/maven_nar/NarSystemMojo.java
@@ -27,17 +27,17 @@ import java.util.Iterator;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
 
 /**
  * Generates a NarSystem class with static methods to use inside the java part of the library.
  * Runs in generate-resources rather than generate-sources to allow the maven-swig-plugin (which runs in
  * generate-sources) to configure the nar plugin and to let it generate a proper system file. 
  * 
- * @goal nar-system-generate
- * @phase generate-resources
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-system-generate", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresProject = true)
 public class NarSystemMojo
     extends AbstractNarMojo
 {

--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -39,25 +39,26 @@ import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
 /**
  * Compiles native test source files.
  * 
- * @goal nar-testCompile
- * @phase test-compile
- * @requiresDependencyResolution test
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-testCompile", defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST)
 public class NarTestCompileMojo
     extends AbstractCompileMojo
 {
     /**
      * Skip running of NAR integration test plugins.
-     * 
-     * @parameter property="skipNar" default-value="false"
      */
+    @Parameter(property = "skipNar")
     protected boolean skipNar;
 
 	@Override

--- a/src/main/java/com/github/maven_nar/NarTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestMojo.java
@@ -30,36 +30,32 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Tests NAR files. Runs Native Tests and executables if produced.
  * 
- * @goal nar-test
- * @phase test
- * @requiresProject
- * @requiresDependencyResolution test
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-test", defaultPhase = LifecyclePhase.TEST, requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class NarTestMojo
     extends AbstractCompileMojo
 {
     /**
      * The classpath elements of the project being tested.
-     * 
-     * @parameter default-value="${project.testClasspathElements}"
-     * @required
-     * @readonly
      */
+    @Parameter(defaultValue = "${project.testClasspathElements}", required = true, readonly = true)
     private List classpathElements;
 
     /**
      * Directory for test resources. Defaults to src/test/resources
-     * 
-     * @parameter default-value="${basedir}/src/test/resources"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/test/resources", required = true)
     private File testResourceDirectory;
 
     @Override

--- a/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
@@ -24,17 +24,16 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Goal that unpacks the project dependencies from the repository to a defined location.
  * Unpacking happens in the local repository, and also sets flags on binaries and corrects static libraries.
- * 
- * @goal nar-unpack-dependencies
- * @phase process-test-sources
- * @requiresProject
- * @requiresDependencyResolution test
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-unpack-dependencies", defaultPhase = LifecyclePhase.PROCESS_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, requiresProject = true)
 public class NarUnpackDependenciesMojo
     extends NarDownloadDependenciesMojo
 {

--- a/src/main/java/com/github/maven_nar/NarUnpackMojo.java
+++ b/src/main/java/com/github/maven_nar/NarUnpackMojo.java
@@ -24,16 +24,17 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Unpacks NAR files. Unpacking happens in the local repository, and also sets flags on binaries and corrects static
  * libraries.
  * 
- * @goal nar-unpack
- * @phase process-sources
- * @requiresProject
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-unpack", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true)
 public class NarUnpackMojo
     extends NarDownloadMojo
 {

--- a/src/main/java/com/github/maven_nar/NarValidateMojo.java
+++ b/src/main/java/com/github/maven_nar/NarValidateMojo.java
@@ -21,6 +21,9 @@ package com.github.maven_nar;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 
@@ -29,20 +32,17 @@ import java.util.List;
 
 /**
  * Validates the configuration of the NAR project (aol and pom)
- * 
- * @goal nar-validate
- * @phase validate
+ *
  * @author Mark Donszelmann
  */
+@Mojo(name = "nar-validate", defaultPhase = LifecyclePhase.VALIDATE)
 public class NarValidateMojo
     extends AbstractCompileMojo
 {
     /**
      * Source directory for GNU style project
-     * 
-     * @parameter default-value="${basedir}/src/gnu"
-     * @required
      */
+    @Parameter(defaultValue = "${basedir}/src/gnu", required = true)
     private File gnuSourceDirectory;
     
 	@Override

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -23,6 +23,9 @@ import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 
@@ -30,12 +33,10 @@ import org.apache.tools.ant.Project;
  * Generates a Visual Studio 2005 project file (vcproj) Heavily inspired by
  * NarCompileMojo.
  * 
- * @goal nar-vcproj
- * @phase generate-sources
- * @requiresDependencyResolution compile
  * @author Darren Sargent
  * 
  */
+@Mojo(name = "nar-vcproj", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarVcprojMojo extends AbstractCompileMojo {
 
 	@Override

--- a/src/main/java/com/github/maven_nar/ProcessLibraryCommand.java
+++ b/src/main/java/com/github/maven_nar/ProcessLibraryCommand.java
@@ -3,27 +3,26 @@ package com.github.maven_nar;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.plugins.annotations.Parameter;
+
 public class ProcessLibraryCommand {
     
     /**
      * The executable to run
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String executable;
     
     /**
      * The library type that this command is valid for
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private String libraryType;
     
     /**
      * Any additional arguments to pass into the executable
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List<String> arguments;
     
     public List<String> getCommandList() {

--- a/src/main/java/com/github/maven_nar/SysLib.java
+++ b/src/main/java/com/github/maven_nar/SysLib.java
@@ -24,6 +24,7 @@ import com.github.maven_nar.cpptasks.types.LibraryTypeEnum;
 import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.Project;
 
 /**
@@ -35,18 +36,14 @@ public class SysLib
 {
     /**
      * Name of the system library
-     * 
-     * @parameter default-value=""
-     * @required
      */
+    @Parameter(required = true)
     private String name;
 
     /**
      * Type of linking for this system library
-     * 
-     * @parameter default-value="shared"
-     * @required
      */
+    @Parameter(defaultValue = "shared")
     private String type = Library.SHARED;
 
     public final SystemLibrarySet getSysLibSet( Project antProject )

--- a/src/main/java/com/github/maven_nar/Test.java
+++ b/src/main/java/com/github/maven_nar/Test.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Sets up a test to create
@@ -35,31 +36,26 @@ public class Test
 
     /**
      * Name of the test to create
-     * 
-     * @required
-     * @parameter default-value=""
      */
+    @Parameter(required = true)
     private String name = null;
 
     /**
      * Type of linking used for this test Possible choices are: "shared" or "static". Defaults to "shared".
-     * 
-     * @parameter default-value=""
      */
+    @Parameter(defaultValue = "shared")
     private String link = Library.SHARED;
 
     /**
      * When true run this test. Defaults to true;
-     * 
-     * @parameter expresssion=""
      */
+    @Parameter(defaultValue = "true")
     private boolean run = true;
 
     /**
      * Arguments to be used for running this test. Defaults to empty list. This option is only used if run=true.
-     * 
-     * @parameter default-value=""
      */
+    @Parameter
     private List/* <String> */args = new ArrayList();
 
     public final String getName()

--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -1764,7 +1764,7 @@ public class CCTask extends Task {
      * 
      * ( CUtil.runCommand() will honor this... )
      * 
-     * @parameter commandLogLevel  The log-level for command-logs, default is MSG_VERBOSE.
+     * @param commandLogLevel  The log-level for command-logs, default is MSG_VERBOSE.
      */
     public void setCommandLogLevel( int commandLogLevel ) {
 	this.commandLogLevel = commandLogLevel;


### PR DESCRIPTION
_Not proposed for merging yet; I intend to continue with the 3-ification by changing the goals to use annotations_
- Parent pom updated to current version from upstream.
- Maven core components pulled from that version.
- Obsolete Maven artifacts removed: maven-project, maven-toolchain.
- maven-compat added to avoid rewriting code that uses the ArtifactResolver.
- Other dependencies brought to current.
- enforcer configured to disable unwanted check from parent.
- junit up to 4.11 to get access to rules.

I picked 3.0.4 because that's my local baseline version. 
