### PR TITLE
Adding support for xlC compiler

### DIFF
--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -265,6 +265,16 @@ public class Linker
         		version = m.group( 0 ); 
         	}
         }
+        else if ( name.equals( "xlC") )
+        {
+        	NarUtil.runCommand("/usr/vacpp/bin/xlC", new String[] { "-qversion" }, null, null, out, err, dbg, log);
+        	Pattern p = Pattern.compile( "\\d+\\.\\d+" );
+        	Matcher m = p.matcher( out.toString() );
+        	if ( m.find() )
+        	{
+        		version = m.group( 0 );
+        	}
+        }
         else
         {
             throw new MojoFailureException( "Cannot find version number for linker '" + name + "'" );

--- a/src/main/java/com/github/maven_nar/cpptasks/ibm/VisualAgeLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/ibm/VisualAgeLinker.java
@@ -20,6 +20,7 @@
 package com.github.maven_nar.cpptasks.ibm;
 import java.util.Vector;
 
+import com.github.maven_nar.cpptasks.CCTask;
 import com.github.maven_nar.cpptasks.compiler.LinkType;
 import com.github.maven_nar.cpptasks.compiler.Linker;
 import com.github.maven_nar.cpptasks.gcc.AbstractLdLinker;
@@ -49,7 +50,7 @@ public final class VisualAgeLinker extends AbstractLdLinker {
         super(command, "-?", extensions, ignoredExtensions, outputPrefix,
                 outputSuffix, false, null);
     }
-    public void addImpliedArgs(boolean debug, LinkType linkType, Vector<String> args) {
+    public void addImpliedArgs(CCTask task, boolean debug, LinkType linkType, Vector<String> args) {
         if (debug) {
             //args.addElement("-g");
         }

--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -992,3 +992,37 @@ amd64.FreeBSD.gcc.shared.extension=so*
 amd64.FreeBSD.gcc.plugin.extension=so
 amd64.FreeBSD.gcc.jni.extension=so
 
+
+#
+# AIX xlc
+#
+ppc.AIX.linker=xlC
+ 
+ppc.AIX.xlC.cpp.compiler=/usr/vacpp/bin/xlC
+ppc.AIX.xlC.cpp.defines=Dunix
+ppc.AIX.xlC.cpp.options=-V -brtl -qstaticinline -qchar=signed
+ppc.AIX.xlC.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+ppc.AIX.xlC.cpp.excludes=
+ 
+ppc.AIX.xlC.c.compiler=/usr/vacpp/bin/xlC
+ppc.AIX.xlC.c.defines=Dunix
+ppc.AIX.xlC.c.options=-brtl -qstaticinline -qchar=signed
+ppc.AIX.xlC.c.includes=**/*.c
+ppc.AIX.xlC.c.excludes=
+
+ppc.AIX.xlC.java.include=include;include/aix
+ppc.AIX.xlC.java.runtimeDirectory=jre/lib/ppc
+
+ppc.AIX.xlC.lib.prefix=lib
+ppc.AIX.xlC.shared.prefix=lib
+ppc.AIX.xlC.static.extension=a
+ppc.AIX.xlC.shared.extension=a
+ppc.AIX.xlC.plugin.extension=a
+ppc.AIX.xlC.jni.extension=a
+ppc.AIX.xlC.executable.extension=
+
+# FIXME to be removed when NARPLUGIN-137
+ppc.AIX.xlC.static.extension=a
+ppc.AIX.xlC.shared.extension=a
+ppc.AIX.xlC.plugin.extension=a
+ppc.AIX.xlC.jni.extension=a


### PR DESCRIPTION
xlC is a C/C++ compiler from IBM for AIX (an operating system from IBM). Here's a link for more info: http://www-03.ibm.com/software/products/en/xlcaix/
In aol.properties file, the xlC properties have been added.

These additions were necessary because aol.properties did not define xlC for AIX (or any other OS), it only defined g++ for AIX, although the necessary classes for xlC were defined (for example, it is found in CompilerEnum).
In Linker.java, in getVersion() method, the case of xlC was not handled.
Therefore a warning was generated saying "cannot find version number for
linker". This case is added and the warning is no longer generated.

In VisualAgeLinker.java, in the addImpliedArgs() method, the first
argument 'CCTask task' was missing. So this was not overriding the
addImpliedArgs() method of the AbstractLdLinker. This means that the
generated linking command was "xlc -shared", instead of "xlc
-qmkshrobj". Adding the argument fixed this issue.
