### PR TITLE
Duplicate environment variable 'PATH'

### DIFF
--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -550,7 +550,7 @@ public final class NarUtil
         char separator = ' ';
         if ( os.equals( OS.WINDOWS ) )
         {
-            pathName = "Path";
+            pathName = "PATH";
             separator = ';';
         }
         else if ( os.equals( OS.MACOSX ) )


### PR DESCRIPTION
When running some tests, I noticed that the required DLLs were not being
found.
This problem is happening with jdk8 (but not jdk7).
I checked the environment variables used when running a command in
NarUtil.java.
I noticed the PATH variable had a duplicate, one version being 'Path'
and was set by the runCommand method in NarUtils, and the second version
being 'PATH' and coming from the system env vars and was set in
addSystemEnvironment() in Commandline.java (from plexus-utils).
This duplication is happening because addSystemEnvironment() checks if a
certain env var already exists using the code "if (
!envVars.containsKey( key ) )" before copying the one given by the
system. Since in our case one is upper case and the other isn't, the
containsKey method of the map does not detect it, and we add the one
from the systemEnvVars, hence the duplication.
For some reason, jdk7 had no problem with the duplicate PATH variable,
but jdk8 did not like it.
In NarUtils.java, changing 'Path' to 'PATH' solved the problem.
I am using windows 7.
