### PR TITLE
Update IncludePath.java: add default setter

### DIFF
--- a/src/main/java/com/github/maven_nar/IncludePath.java
+++ b/src/main/java/com/github/maven_nar/IncludePath.java
@@ -54,6 +54,9 @@ public class IncludePath {
     public String getPath() {
         return path;
     }
+    public void set(String path) {
+        setPath(path);
+    }
     public void setPath(String path) {
         this.path = path;
         file = new File(path);


### PR DESCRIPTION
Fix for: https://github.com/maven-nar/nar-maven-plugin/issues/142

Method setDefault(...) in class org.eclipse.sisu.plexus.CompositeBeanHelper complains about a missing default setter. This update adds a method "public void set(String path)" that calls setPath(path) which fixes this problem.
