### PR TITLE
Allow the use of the options -p and -pg for gcc linker.

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -42,7 +42,7 @@ public class GccLinker extends AbstractLdLinker {
     	    "-dynamic", "-arch",
             "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s",
             "-static", "-shared", "-symbolic", "-Xlinker",
-            "--export-all-symbols", "-static-libgcc",};
+            "--export-all-symbols", "-static-libgcc", "-p", "-pg"};
 // FREEHEP refactored dllLinker to soLinker
     private static final GccLinker soLinker = new GccLinker("gcc", objFiles,
             discardFiles, "lib", ".so", false, new GccLinker("gcc", objFiles,

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -45,7 +45,7 @@ public class GppLinker extends AbstractLdLinker {
     private static String[] linkerOptions = new String[]{"-bundle", "-dylib",
             "-dynamic", "-dynamiclib", "-nostartfiles", "-nostdlib",
             "-prebind", "-s", "-static", "-shared", "-symbolic", "-Xlinker",
-            "-static-libgcc", "-shared-libgcc"};
+            "-static-libgcc", "-shared-libgcc", "-p", "-pg"};
     // FREEHEP refactored dllLinker into soLinker
     private static final GppLinker soLinker = new GppLinker(GPP_COMMAND, objFiles,
             discardFiles, "lib", ".so", false, new GppLinker(GPP_COMMAND, objFiles,


### PR DESCRIPTION
Gcc linker allow the use of the options -p and -pg for debug purpose
(refer to the end of the message for documentation).

I configured those options in a pom:
<pre>
&lt;linker&gt;
	&lt;name&gt;g++&lt;/name&gt;
	&lt;options&gt;
		&lt;option&gt;-p&lt;/option&gt;
		&lt;option&gt;-pg&lt;/option&gt;
	&lt;/options&gt;
	...
&lt;/linker&gt;
</pre>
On linking step the options -p and -pg are preceded by "-Wl," on the
command line due to the fact that they are not registered in the
linkerOptions in the class com.github.maven_nar.cpptasks.gcc.GppLinker :
<pre>[DEBUG] g++ -Wl,-p -Wl,-pg ...</pre>

I add , "-p", "-pg" in linkerOptions in the classes GppLinker
and GccLinker to allow the use of those options.

-p Generate extra code to write profile information suitable for the
analysis program prof. You must use this option when compiling the
source files you want data about, and you must also use it when linking.
-pg Generate extra code to write profile information suitable for the
analysis program gprof. You must use this option when compiling the
source files you want data about, and you must also use it when linking.