### PR TITLE
Correction of the execution of it0027

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -475,6 +475,7 @@
                 <setupInclude>it0007-lib-shared/pom.xml</setupInclude>
                 <setupInclude>it0010-lib-static/pom.xml</setupInclude>
                 <setupInclude>it0020-lib-3rdparty/pom.xml</setupInclude>
+                <setupInclude>it0026-native-lib-loader/pom.xml</setupInclude>
               </setupIncludes>
               <pomIncludes>
                 <pomInclude>*/pom.xml</pomInclude>


### PR DESCRIPTION
The integration test it0027 depends on it0026(*), thus the "clean
install" of it0026 must be done before the build of it0027.

(*) in it0027-dep-jni-native-lib-loader/pom.xml :
<pre>
&lt;dependency&gt;
	&lt;artifactId&gt;it0026-native-lib-loader&lt;/artifactId&gt;
	&lt;version&gt;1.0-SNAPSHOT&lt;/version&gt;
	&lt;groupId&gt;com.github.maven-nar.its.nar&lt;/groupId&gt;			
	&lt;type&gt;nar&lt;/type&gt;
&lt;/dependency&gt;
</pre>
In nar-maven-plugin/pom.xml in the profile run-its, the plugin
maven-invoker-plugin is used to execute the pom files of the it tests
with the goals clean and install, but the pom files listed by
maven-invoker-plugin are not sorted according to their parent
directories names, example on buildhive on the build #288
<pre>
[INFO] --- maven-invoker-plugin:1.8:run (integration-test) @
nar-maven-plugin ---
...
[DEBUG] Collecting parent/child projects of it0020-lib-3rdparty/pom.xml
[DEBUG] Collecting parent/child projects of it-parent/pom.xml
[DEBUG] Collecting parent/child projects of it0007-lib-shared/pom.xml
...
[DEBUG] Collecting parent/child projects of
it0027-dep-jni-native-lib-loader/pom.xml
...
[DEBUG] Collecting parent/child projects of
it0026-native-lib-loader/pom.xml
...
</pre>
The tests are executed in the order on which they have been collected,
and here the test it0027 appears before it0026, and therefore will be
executed before it0026 and will fail as the dependency
it0026-native-lib-loader will not exist.

The plugin maven-invoker-plugin allows to run a bunch of pom files
before the others by using the setupIncludes configuration, some pom files
are already listed here. Since it0026 doesn't depend on other test I put
it in setupIncludes to ensure that it will be run before it0027.