### PR TITLE
Allow the use of the option -pthread for gcc linker.

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -42,7 +42,8 @@ public class GccLinker extends AbstractLdLinker {
     	    "-dynamic", "-arch",
             "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s",
             "-static", "-shared", "-symbolic", "-Xlinker",
-            "--export-all-symbols", "-static-libgcc", "-p", "-pg"};
+            "--export-all-symbols", "-static-libgcc", "-p", "-pg",
+            "-pthread"};
 // FREEHEP refactored dllLinker to soLinker
     private static final GccLinker soLinker = new GccLinker("gcc", objFiles,
             discardFiles, "lib", ".so", false, new GccLinker("gcc", objFiles,

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -45,7 +45,8 @@ public class GppLinker extends AbstractLdLinker {
     private static String[] linkerOptions = new String[]{"-bundle", "-dylib",
             "-dynamic", "-dynamiclib", "-nostartfiles", "-nostdlib",
             "-prebind", "-s", "-static", "-shared", "-symbolic", "-Xlinker",
-            "-static-libgcc", "-shared-libgcc", "-p", "-pg"};
+            "-static-libgcc", "-shared-libgcc", "-p", "-pg",
+            "-pthread"};
     // FREEHEP refactored dllLinker into soLinker
     private static final GppLinker soLinker = new GppLinker(GPP_COMMAND, objFiles,
             discardFiles, "lib", ".so", false, new GppLinker(GPP_COMMAND, objFiles,


### PR DESCRIPTION
Gcc linker allow the use of the option -pthread for managing pthread
specificity when linking.

I configured this option in a pom:
<pre>
&lt;linker&gt;
	&lt;name&gt;g++&lt;/name&gt;
	&lt;options&gt;
		&lt;option&gt;-pthread&lt;/option&gt;
	&lt;/options&gt;
	...
&lt;/linker&gt;
</pre>
On linking step the option -pthread is preceded by "-Wl," on the
command line due to the fact that it is not registered in the
linkerOptions in the class com.github.maven_nar.cpptasks.gcc.GppLinker :
<pre>[DEBUG] g++ -Wl,-pthread ...</pre>

This commit add , "-pthread" in linkerOptions in the classes GppLinker
and GccLinker.