### PR TITLE
Refactor download-and-unpack dependencies, and add integration tests concerning dependencies scopes

### DIFF
--- a/src/it/it0025-jar-dep-jni/pom.xml
+++ b/src/it/it0025-jar-dep-jni/pom.xml
@@ -56,6 +56,12 @@
             </goals>
           </execution>
           <execution>
+            <id>nar-test-unpack</id>
+            <goals>
+              <goal>nar-test-unpack</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>nar-integration-test</id>
             <goals>
               <goal>nar-integration-test</goal>

--- a/src/it/it0027-dep-jni-native-lib-loader/pom.xml
+++ b/src/it/it0027-dep-jni-native-lib-loader/pom.xml
@@ -26,8 +26,8 @@
 	<name>NAR JNI and Shared Library</name>
 	<version>1.0-SNAPSHOT</version>
 	<description>Depends on it0026-native-lib-loader
-     depending on JNI library that uses  native lib loader  to load.
-  </description>
+	depending on JNI library that uses  native lib loader  to load.
+	</description>
 
 	<properties>
 		<skipTests>true</skipTests>
@@ -48,6 +48,12 @@
 						</goals>
 					</execution>					
 					<execution>
+						<id>nar-test-unpack</id>
+						<goals>
+							<goal>nar-test-unpack</goal>
+						</goals>
+					</execution>
+					<execution>
 						<id>nar-integration-test</id>
 						<goals>
 							<goal>nar-integration-test</goal>
@@ -60,8 +66,8 @@
 
 	<dependencies>
 		<dependency>
-			 <artifactId>it0026-native-lib-loader</artifactId>
-    			<version>1.0-SNAPSHOT</version>
+			<artifactId>it0026-native-lib-loader</artifactId>
+			<version>1.0-SNAPSHOT</version>
 			<groupId>com.github.maven-nar.its.nar</groupId>			
 			<type>nar</type>
 		</dependency>

--- a/src/it/it0028-scope/app/pom.xml
+++ b/src/it/it0028-scope/app/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-app</artifactId>
+  <packaging>nar</packaging>
+
+  <name>Application</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Application using the libraries of it0028.
+    The library compile-shared is defined as a dependency with the scope compile, this give also acces to the library
+    system-shared for compilation, test compilation (not used for executable) and execution. The library provided-static
+    is not recovered through compile-shared due to the scope provided, and then its header files can't be included in
+    the application code. The library test-shared is not recovered either due to the scope test in compile-shared.
+    The library runtime-shared as been declared as as dependency with the scope runtime in the library compile-shared
+    to allow the execution of the test of compile-shared, the scope runtime is transitive so the library runtime-shared
+    is automatically added as a runtime library the the application. Note that if we remove the test of compile-shared
+    and we remove the runtime-shared dependency in compile-shared, runtime-shared will have to be declared as a runtime
+    dependency for the application.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <run>true</run>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0028-scope-compile-shared</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0028-scope/app/src/main/c/Application.c
+++ b/src/it/it0028-scope/app/src/main/c/Application.c
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <Operations.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	long n1, n2, n3, result, value;
+
+	n1 = 2;
+	n2 = 6;
+	n3 = 3;
+	value = 4;
+
+	result = Operation1(n1, n2, n3);
+
+	printf("Operation1 : %ld\n", result);
+
+	/* If the dynamic library loading succeeds the result of Operation1 will be 4 */
+	if(result == value) {
+		return 0;
+	} else {
+		return 1;
+	}
+}

--- a/src/it/it0028-scope/compile-shared/pom.xml
+++ b/src/it/it0028-scope/compile-shared/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-compile-shared</artifactId>
+  <packaging>nar</packaging>
+
+  <name>Compile Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Maven definition of scope compile:
+    This is the default scope, used if none is specified. Compile dependencies are available in all classpaths of a
+    project. Furthermore, those dependencies are propagated to dependent projects.
+    
+    For NAR artifacts this scope can be used for standard libraries as it is for Java.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+
+  </build>
+  
+  <profiles>
+    <profile>
+      <id>Windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <libraries>
+                <library>
+                  <type>shared</type>
+                </library>
+              </libraries>
+              <linker>
+                <sysLibs>
+                  <!-- Kernel32 seems to be automatically linked -->
+                  <!-- <sysLib>
+                    <name>Kernel32</name>
+                    <type>shared</type>
+                  </sysLib> -->
+                </sysLibs>
+              </linker>
+              <tests>
+                <test>
+                  <name>OperationsTest</name>
+                  <link>shared</link>
+                </test>
+              </tests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>Unix</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <libraries>
+                <library>
+                  <type>shared</type>
+                </library>
+              </libraries>
+              <linker>
+                <sysLibs>
+                  <sysLib>
+                    <name>dl</name>
+                    <type>shared</type>
+                  </sysLib>
+                </sysLibs>
+              </linker>
+              <tests>
+                <test>
+                  <name>OperationsTest</name>
+                  <link>shared</link>
+                </test>
+              </tests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0028-scope-system-shared</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/../system-shared/target/it0028-scope-system-shared-1.0-SNAPSHOT.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0028-scope-provided-static</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0028-scope-test-shared</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0028-scope-runtime-shared</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0028-scope/compile-shared/src/main/c/Operations.c
+++ b/src/it/it0028-scope/compile-shared/src/main/c/Operations.c
@@ -1,0 +1,44 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "Operations.h"
+
+#include <CallDynamicOperation.h>
+#include <SystemOperation.h>
+
+#include <string.h>
+
+long Operation1(long n1, long n2, long n3) {
+	long result;
+
+	/* 
+	 * CallDynamicOperation take in first parameter the file name of the library to load.
+	 * The directory containing the library file is added to the path by nar-maven-plugin
+	 * test goal, so we only need the library name (without its path) to load it
+	 */
+#ifdef WIN32
+	result = CallDynamicOperation("it0028-scope-runtime-shared-1.0-SNAPSHOT.dll", n1, n2);
+#else
+	result = CallDynamicOperation("libit0028-scope-runtime-shared-1.0-SNAPSHOT.so", n1, n2);
+#endif
+
+	result = SystemOperation(result, n3);
+
+	return result;
+}

--- a/src/it/it0028-scope/compile-shared/src/main/include/Operations.h
+++ b/src/it/it0028-scope/compile-shared/src/main/include/Operations.h
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef Operation1_H
+#define Operation1_H
+
+#ifdef WIN32
+__declspec(dllexport)
+#endif
+extern long Operation1(long n1, long n2, long n3);
+
+#endif

--- a/src/it/it0028-scope/compile-shared/src/test/c/OperationsTest.c
+++ b/src/it/it0028-scope/compile-shared/src/test/c/OperationsTest.c
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "Operations.h"
+#include <Compare.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	long n1, n2, n3, result, value;
+	char compResult;
+
+	n1 = 2;
+	n2 = 6;
+	n3 = 3;
+	value = 4;
+
+	result = Operation1(n1, n2, n3);
+	/* If the dynamic library loading succeeds the result of Operation1 will be 4 */
+	compResult = CompareLong(result, value);
+
+	printf("Test Operation1 : %d\n", compResult);
+	return compResult;
+}
+
+

--- a/src/it/it0028-scope/pom.xml
+++ b/src/it/it0028-scope/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0028-scope</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Aggregator of tests of scopes</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Test of libraries with different scopes
+  </description>
+
+  <modules>
+    <module>system-shared</module>
+    <module>runtime-shared</module>
+    <module>provided-static</module>
+    <module>test-shared</module>
+    <module>compile-shared</module>
+    <module>app</module>
+  </modules>
+
+</project>

--- a/src/it/it0028-scope/provided-static/pom.xml
+++ b/src/it/it0028-scope/provided-static/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-provided-static</artifactId>
+  <packaging>nar</packaging>
+
+  <name>Provided Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Maven definition of scope provided:
+    This is much like compile, but indicates you expect the JDK or a container to provide the dependency at runtime.
+    For example, when building a web application for the Java Enterprise Edition, you would set the dependency on the
+    Servlet API and related Java EE APIs to scope provided because the web container provides those classes. This scope
+    is only available on the compilation and test classpath, and is not transitive.
+    
+    For NAR artifacts this scope can be used for static libraries, in Java the library must be provided at runtime by
+    the JDK or a container, in NAR the library will be provided inside the other libraries or applications as it is
+    statically linked. Libraries with this scope are not transitive, so this scope is valid only if the header files of
+    the library is used only in the libraries or applications which define this dependency.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0028-scope/provided-static/src/main/c/CallDynamicOperation.c
+++ b/src/it/it0028-scope/provided-static/src/main/c/CallDynamicOperation.c
@@ -1,0 +1,103 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "CallDynamicOperation.h"
+
+#include <stdio.h>
+
+#ifdef WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#ifdef WIN32
+const char *w32error(int i_code, TCHAR *msgBuf, unsigned int size) {
+	DWORD res = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, /* dwFlags */
+	NULL, /* lpSource */
+	i_code, /* dwMessageId */
+	MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), /* dwLanguageId */
+	(LPTSTR) msgBuf, /* lpBuffer */
+	size, /* nSize */
+	NULL /* Arguments */);
+
+	if (!res && size >= 50) {
+		sprintf(msgBuf, "Error %d in FormatMessage for the code %d\n", (int) res, i_code);
+	}
+
+	return msgBuf;
+}
+#endif
+
+long CallDynamicOperation(const char *libDynamicOperationPath, long n1, long n2) {
+	long result;
+
+	typedef long (*DynamicOperation_type)(long, long);
+	DynamicOperation_type DynamicOperation;
+
+#ifdef WIN32
+
+	HINSTANCE library = NULL;
+	TCHAR msgBuf[255];
+
+	library = LoadLibrary(libDynamicOperationPath);
+	if (library == NULL) {
+		printf("CallDynamicOperation: LoadLibrary failed : %s\n", w32error(GetLastError(), msgBuf, 255));
+		return 0;
+	}
+
+	DynamicOperation = (DynamicOperation_type)GetProcAddress((HMODULE)library, "DynamicOperation");
+	if (DynamicOperation == NULL) {
+		printf("CallDynamicOperation: GetProcAddress failed : %s\n", w32error(GetLastError(), msgBuf, 255));
+		return 0;
+	}
+
+	result = (*DynamicOperation)(n1, n2);
+
+	FreeLibrary(library);
+
+#else
+
+	void *handle;
+	char *error;
+
+	handle = dlopen(libDynamicOperationPath, RTLD_LAZY);
+	if (!handle) {
+		printf("CallDynamicOperation: dlopen failed : %s\n", dlerror());
+		return 0;
+	}
+
+	/* Clear any existing error */
+	dlerror();
+
+	DynamicOperation = (DynamicOperation_type)dlsym(handle, "DynamicOperation");
+	if ((error = dlerror()) != 0) {
+		printf("CallDynamicOperation: dlsym failed : %s\n", error);
+		return 0;
+	}
+
+	result = (*DynamicOperation)(n1, n2);
+
+	dlclose(handle);
+
+#endif
+
+	return result;
+}
+

--- a/src/it/it0028-scope/provided-static/src/main/include/CallDynamicOperation.h
+++ b/src/it/it0028-scope/provided-static/src/main/include/CallDynamicOperation.h
@@ -1,0 +1,25 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef CallDynamicOperation_H
+#define CallDynamicOperation_H
+
+extern long CallDynamicOperation(const char *libDynamicOperationPath, long n1, long n2);
+
+#endif

--- a/src/it/it0028-scope/runtime-shared/pom.xml
+++ b/src/it/it0028-scope/runtime-shared/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-runtime-shared</artifactId>
+  <packaging>nar</packaging>
+
+  <name>Runtime Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Maven definition of scope runtime:
+    This scope indicates that the dependency is not required for compilation, but is for execution. It is in the
+    runtime and test classpaths, but not the compile classpath.
+    
+    For NAR artifacts this scope can be used for libraries linked during execution with the function dlopen for Unix or
+    LoadLibrary for Windows. Those libraries are not required for compilation and linking.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0028-scope/runtime-shared/src/main/c/DynamicOperation.c
+++ b/src/it/it0028-scope/runtime-shared/src/main/c/DynamicOperation.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+#ifdef WIN32
+__declspec(dllexport)
+#endif
+long DynamicOperation(long n1, long n2);
+
+long DynamicOperation(long n1, long n2) {
+	return n1*n2;
+}

--- a/src/it/it0028-scope/system-shared/pom.xml
+++ b/src/it/it0028-scope/system-shared/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-system-shared</artifactId>
+  <packaging>nar</packaging>
+
+  <name>System Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Maven definition of scope system:
+    This scope is similar to provided except that you have to provide the JAR which contains it explicitly.
+    The artifact is always available and is not looked up in a repository.
+    
+    For NAR artifacts this scope can be used to create libraries with system dependant code, each library or
+    application using this library will have to set the absolute path of the nar files. This can be used to use a
+    library already built for the system.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0028-scope/system-shared/src/main/c/SystemOperation.c
+++ b/src/it/it0028-scope/system-shared/src/main/c/SystemOperation.c
@@ -1,0 +1,34 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "SystemOperation.h"
+
+long SystemOperation(long n1, long n2) {
+	if(n2 != 0) {
+		return n1/n2;
+	} else {
+		// return the max value as infinity
+		if(n1 >= 0) {
+			return 2147483647;
+		} else {
+			return -2147483647;
+		}
+	}
+}
+

--- a/src/it/it0028-scope/system-shared/src/main/include/SystemOperation.h
+++ b/src/it/it0028-scope/system-shared/src/main/include/SystemOperation.h
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef SystemOperation_H
+#define SystemOperation_H
+
+#ifdef WIN32
+__declspec(dllexport)
+#endif
+extern long SystemOperation(long n1, long n2);
+
+#endif

--- a/src/it/it0028-scope/test-shared/pom.xml
+++ b/src/it/it0028-scope/test-shared/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0028-scope</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0028-scope-test-shared</artifactId>
+  <packaging>nar</packaging>
+
+  <name>Test Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Maven definition of scope test:
+    This scope indicates that the dependency is not required for normal use of the application, and is only available
+    for the test compilation and execution phases.
+    
+    For NAR artifacts this scope can be used for test libraries, like a test runner for example.
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0028-scope/test-shared/src/main/c/Compare.c
+++ b/src/it/it0028-scope/test-shared/src/main/c/Compare.c
@@ -1,0 +1,29 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include "Compare.h"
+
+char CompareLong(long n1, long n2) {
+	/*
+	 * n1 = n2 : 0
+	 * n1 > n2 : positive value
+	 * n1 < n2 : negative value
+	 */
+	return n1 - n2;
+}

--- a/src/it/it0028-scope/test-shared/src/main/include/Compare.h
+++ b/src/it/it0028-scope/test-shared/src/main/include/Compare.h
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef Equals_H
+#define Equals_H
+
+#ifdef WIN32
+__declspec(dllexport)
+#endif
+extern char CompareLong(long n1, long n2);
+
+#endif

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -88,16 +88,30 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
 				getMavenProject(), getArchitecture(), getOS(), getLinker());
 	}
 
-    protected List<Artifact> getArtifacts() {
-        try {
-            return getNarManager().getNarDependencies(Artifact.SCOPE_COMPILE);
-        } catch (MojoExecutionException e) {
-            e.printStackTrace();
-        } catch (MojoFailureException e) {
-            e.printStackTrace();
-        }
-        return Collections.EMPTY_LIST;
-    }
+	/**
+	 * Returns the artifacts which must be taken in account for the Mojo.
+	 * 
+	 * @return Artifacts
+	 */
+    protected abstract List<Artifact> getArtifacts();
+
+	/**
+	 * Returns the attached NAR Artifacts (AOL and noarch artifacts) from the NAR dependencies artifacts of the project.
+	 * The artifacts which will be processed are those returned by the method getArtifacts() which must be implemented
+	 * in each class which extends AbstractDependencyMojo.
+     * 
+	 * @return Attached NAR Artifacts
+	 * @throws MojoFailureException
+	 * @throws MojoExecutionException
+	 * 
+	 * @see getArtifacts
+	 */
+	protected List<AttachedNarArtifact> getAttachedNarArtifacts() throws MojoFailureException ,MojoExecutionException {
+		getLog().info("Getting Nar dependencies");
+		List<NarArtifact> narArtifacts = getNarArtifacts( );
+		List<AttachedNarArtifact> attachedNarArtifacts = getAllAttachedNarArtifacts( narArtifacts/*, library*/ );
+		return attachedNarArtifacts;
+	}
 
 	/**
 	 * Returns dependencies which are dependent on NAR files (i.e. contain
@@ -302,14 +316,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     		    // AOL aol = dependency.getClassifier();  Trim
     		    layout.unpackNar(unpackDir, archiverManager, file, getOS(), getLinker().getName(), getAOL() );            
     	    }
-        }    
-
-	public void narExecute() throws MojoFailureException ,MojoExecutionException {
-		getLog().info("Preparing Nar dependencies");
-		List<NarArtifact> narArtifacts = getNarArtifacts( );
-		List<AttachedNarArtifact> dependencies = getAllAttachedNarArtifacts( narArtifacts/*, library*/ );
-		downloadAttachedNars( dependencies );
-		unpackAttachedNars( dependencies );
-	};
+        }
 
 }

--- a/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -88,13 +89,30 @@ import org.codehaus.plexus.util.StringUtils;
  * @version $Id: SurefirePlugin.java 652773 2008-05-02 05:58:54Z dfabulich $ Mods by Duns for NAR
  */
 // DUNS, changed class name, inheritance, goal and phase
-@Mojo(name = "nar-integration-test", requiresDependencyResolution = ResolutionScope.TEST, defaultPhase = LifecyclePhase.INTEGRATION_TEST)
+@Mojo(name = "nar-integration-test", defaultPhase = LifecyclePhase.INTEGRATION_TEST, requiresDependencyResolution = ResolutionScope.TEST)
 public class NarIntegrationTestMojo
     extends AbstractDependencyMojo
 {
+	/**
+     * List the dependencies needed for integration tests executions, those dependencies are used to declare the paths
+     * of shared and jni libraries in java.library.path
+     */
 	@Override
-	protected List/*<Artifact>*/ getArtifacts() {
-		return getMavenProject().getTestArtifacts();  // Artifact.SCOPE_TEST 
+	protected List<Artifact> getArtifacts() {
+		try {
+			List<String> scopes = new ArrayList<String>();
+    		scopes.add(Artifact.SCOPE_COMPILE);
+    		scopes.add(Artifact.SCOPE_PROVIDED);
+    		scopes.add(Artifact.SCOPE_RUNTIME);
+    		scopes.add(Artifact.SCOPE_SYSTEM);
+    		scopes.add(Artifact.SCOPE_TEST);
+    		return getNarManager().getDependencies(scopes);
+        } catch (MojoExecutionException e) {
+            e.printStackTrace();
+        } catch (MojoFailureException e) {
+            e.printStackTrace();
+        }
+        return Collections.EMPTY_LIST;
 	}
 
     protected File getUnpackDirectory()
@@ -512,7 +530,6 @@ public class NarIntegrationTestMojo
         }
         else if ( verifyParameters() )
         {
-            super.narExecute();
 
             SurefireBooter surefireBooter = constructSurefireBooter();
 

--- a/src/main/java/com/github/maven_nar/NarManager.java
+++ b/src/main/java/com/github/maven_nar/NarManager.java
@@ -72,8 +72,19 @@ public class NarManager
 	public final List/* <NarArtifact> */getNarDependencies(String scope)
         throws MojoExecutionException
     {
+		List<String> scopes = new ArrayList<String>();
+		scopes.add(scope);
+		return getNarDependencies(scopes);
+	}
+
+	/**
+     * Returns dependencies which are dependent on NAR files (i.e. contain NarInfo)
+	 */
+	public final List/* <NarArtifact> */getNarDependencies(List<String> scopes)
+        throws MojoExecutionException
+    {
 		List narDependencies = new LinkedList();
-        for ( Iterator i = getDependencies( scope ).iterator(); i.hasNext(); )
+        for ( Iterator i = getDependencies( scopes ).iterator(); i.hasNext(); )
         {
 			Artifact dependency = (Artifact) i.next();
 			log.debug("Examining artifact for NarInfo: " + dependency);
@@ -328,12 +339,12 @@ public class NarManager
                                                                    repository.pathOf( dependency ) ) );
 	}
 
-    private List getDependencies( String scope )
+    public List/*<Artifact>*/ getDependencies( List<String> scopes )
     {
         Set<Artifact> artifacts = project.getArtifacts();
         List<Artifact> returnArtifact = new ArrayList<Artifact>();
         for(Artifact a : artifacts) {
-            if(scope.equals(a.getScope()))
+            if(scopes.contains(a.getScope()))
                 returnArtifact.add(a);
         }
         return returnArtifact;

--- a/src/main/java/com/github/maven_nar/NarProcessLibraries.java
+++ b/src/main/java/com/github/maven_nar/NarProcessLibraries.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -51,10 +52,12 @@ public class NarProcessLibraries extends AbstractCompileMojo {
 
     private Log log = getLog();
 
+    /**
+     * The method must be implemented but will not be called.
+     */
     @Override
-    protected List getArtifacts() {
-        //TODO: Added to get code compiling after rebasing.  Should this have a concrete implementation in AbstractCompileMojo?
-        return null;
+    protected List<Artifact> getArtifacts() {
+    	return Collections.EMPTY_LIST;
     }
 
     @Override

--- a/src/main/java/com/github/maven_nar/NarTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestMojo.java
@@ -22,8 +22,10 @@ package com.github.maven_nar;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -58,9 +60,26 @@ public class NarTestMojo
     @Parameter(defaultValue = "${basedir}/src/test/resources", required = true)
     private File testResourceDirectory;
 
+    /**
+     * List the dependencies needed for tests executions and for executables executions, those dependencies are used
+     * to declare the paths of shared libraries for execution.
+     */
     @Override
-    protected List/*<Artifact>*/ getArtifacts() {
-        return getMavenProject().getTestArtifacts();  // Artifact.SCOPE_TEST
+    protected List<Artifact> getArtifacts() {
+    	try {
+    		List<String> scopes = new ArrayList<String>();
+    		scopes.add(Artifact.SCOPE_COMPILE);
+    		scopes.add(Artifact.SCOPE_PROVIDED);
+    		scopes.add(Artifact.SCOPE_RUNTIME);
+    		scopes.add(Artifact.SCOPE_SYSTEM);
+    		scopes.add(Artifact.SCOPE_TEST);
+    		return getNarManager().getDependencies(scopes);
+        } catch (MojoExecutionException e) {
+            e.printStackTrace();
+        } catch (MojoFailureException e) {
+            e.printStackTrace();
+        }
+        return Collections.EMPTY_LIST;
     }
 
     protected File getUnpackDirectory()
@@ -77,7 +96,7 @@ public class NarTestMojo
         }
         else
         {
-            super.narExecute();
+
             // run all tests
             for ( Iterator i = getTests().iterator(); i.hasNext(); )
             {

--- a/src/main/java/com/github/maven_nar/NarTestUnpackMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestUnpackMojo.java
@@ -19,6 +19,7 @@
  */
 package com.github.maven_nar;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -32,18 +33,18 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Unpacks NAR files needed for compilation. Unpacking happens in the project target folder, and also sets flags on
- * binaries and corrects static libraries.
+ * Unpacks NAR files needed for tests compilation and execution. Unpacking happens in the project target folder, and
+ * also sets flags on binaries and corrects static libraries.
  * 
  * @author Mark Donszelmann
  */
-@Mojo(name = "nar-unpack", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.COMPILE)
-public class NarUnpackMojo
+@Mojo(name = "nar-test-unpack", defaultPhase = LifecyclePhase.GENERATE_TEST_SOURCES, requiresProject = true, requiresDependencyResolution = ResolutionScope.TEST)
+public class NarTestUnpackMojo
     extends AbstractDependencyMojo
 {
 
 	/**
-	 * List the dependencies needed for compilation.
+	 * List the dependencies needed for tests compilations and executions.
 	 */
 	@Override
     protected List<Artifact> getArtifacts() {
@@ -51,9 +52,9 @@ public class NarUnpackMojo
 			List<String> scopes = new ArrayList<String>();
     		scopes.add(Artifact.SCOPE_COMPILE);
     		scopes.add(Artifact.SCOPE_PROVIDED);
-    		//scopes.add(Artifact.SCOPE_RUNTIME);
+    		scopes.add(Artifact.SCOPE_RUNTIME);
     		scopes.add(Artifact.SCOPE_SYSTEM);
-    		//scopes.add(Artifact.SCOPE_TEST);
+    		scopes.add(Artifact.SCOPE_TEST);
     		return getNarManager().getDependencies(scopes);
         } catch (MojoExecutionException e) {
             e.printStackTrace();
@@ -62,6 +63,12 @@ public class NarUnpackMojo
         }
         return Collections.EMPTY_LIST;
 	}
+
+	@Override
+    protected File getUnpackDirectory()
+    {
+        return getTestUnpackDirectory() == null ? super.getUnpackDirectory() : getTestUnpackDirectory();
+    }
 
     @Override
     public final void narExecute()

--- a/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
@@ -19,7 +19,6 @@
  */
 package com.github.maven_nar;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -29,13 +28,25 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Goal that unpacks the project dependencies from the repository to a defined location.
- * Unpacking happens in the local repository, and also sets flags on binaries and corrects static libraries.
+ * List all the dependencies of the project and downloads the NAR files in local maven repository if needed, this
+ * includes the noarch and aol type NAR files, and then unpack the files in the project target folder. This also sets
+ * flags on binaries and corrects static libraries.
+ * 
  * @author Mark Donszelmann
  */
-@Mojo(name = "nar-unpack-dependencies", defaultPhase = LifecyclePhase.PROCESS_TEST_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, requiresProject = true)
+@Mojo(name = "nar-unpack-dependencies", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.TEST, requiresProject = true)
 public class NarUnpackDependenciesMojo
     extends NarDownloadDependenciesMojo
 {
-	// get them all
+
+	@Override
+	public void narExecute() throws MojoFailureException, MojoExecutionException {
+		// download the dependencies if needed in local maven repository using NarDownloadDependenciesMojo
+		super.narExecute();
+		
+        // unpack the nar files
+		List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    	unpackAttachedNars( attachedNarArtifacts );
+	}
+
 }

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -21,6 +21,8 @@ package com.github.maven_nar;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -40,6 +42,7 @@ import com.github.maven_nar.cpptasks.types.LibrarySet;
 import com.github.maven_nar.cpptasks.types.LinkerArgument;
 import com.github.maven_nar.cpptasks.types.SystemLibrarySet;
 
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -55,14 +58,32 @@ import org.apache.tools.ant.Project;
  * @author Darren Sargent
  * 
  */
-@Mojo(name = "nar-vcproj", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresDependencyResolution = ResolutionScope.COMPILE)
+@Mojo(name = "nar-vcproj", defaultPhase = LifecyclePhase.GENERATE_RESOURCES, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class NarVcprojMojo extends AbstractCompileMojo {
 
+	/**
+	 * List the dependencies needed for compilation, those dependencies are used to get the include paths needed for
+	 * compilation and to get the libraries paths and names needed for linking.
+	 */
 	@Override
-	protected List/*<Artifact>*/ getArtifacts() {
-		return getMavenProject().getCompileArtifacts();  // Artifact.SCOPE_COMPILE 
+	protected List<Artifact> getArtifacts() {
+		try {
+			List<String> scopes = new ArrayList<String>();
+    		scopes.add(Artifact.SCOPE_COMPILE);
+    		scopes.add(Artifact.SCOPE_PROVIDED);
+    		//scopes.add(Artifact.SCOPE_RUNTIME);
+    		scopes.add(Artifact.SCOPE_SYSTEM);
+    		//scopes.add(Artifact.SCOPE_TEST);
+    		return getNarManager().getDependencies(scopes);
+        } catch (MojoExecutionException e) {
+            e.printStackTrace();
+        } catch (MojoFailureException e) {
+            e.printStackTrace();
+        }
+        return Collections.EMPTY_LIST;
 	}
 
+	@Override
 	public void narExecute() throws MojoExecutionException,
 			MojoFailureException {
 

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -27,54 +27,74 @@
 			</implementation>
 			<configuration>
 				<phases>
-					<validate>com.github.maven-nar:nar-maven-plugin:nar-validate
+					<validate>
+						com.github.maven-nar:nar-maven-plugin:nar-validate
 					</validate>
-					<initialize></initialize>
-					<generate-sources>com.github.maven-nar:nar-maven-plugin:nar-download
+					<initialize>
+						com.github.maven-nar:nar-maven-plugin:nar-download
+					</initialize>
+					<generate-sources>
+						com.github.maven-nar:nar-maven-plugin:nar-unpack
 					</generate-sources>
-					<process-sources>com.github.maven-nar:nar-maven-plugin:nar-unpack,
+					<process-sources>
 						com.github.maven-nar:nar-maven-plugin:nar-gnu-configure
 					</process-sources>
-					<generate-resources>com.github.maven-nar:nar-maven-plugin:nar-system-generate
-					</generate-resources>
-					<process-resources>org.apache.maven.plugins:maven-resources-plugin:resources,
-						com.github.maven-nar:nar-maven-plugin:nar-resources,
-						com.github.maven-nar:nar-maven-plugin:nar-gnu-resources,
+					<generate-resources>
+						com.github.maven-nar:nar-maven-plugin:nar-system-generate,
 						com.github.maven-nar:nar-maven-plugin:nar-vcproj
+					</generate-resources>
+					<process-resources>
+						org.apache.maven.plugins:maven-resources-plugin:resources,
+						com.github.maven-nar:nar-maven-plugin:nar-resources,
+						com.github.maven-nar:nar-maven-plugin:nar-gnu-resources
 					</process-resources>
-					<compile>org.apache.maven.plugins:maven-compiler-plugin:compile,
+					<compile>
+						org.apache.maven.plugins:maven-compiler-plugin:compile,
 						com.github.maven-nar:nar-maven-plugin:nar-javah,
 						com.github.maven-nar:nar-maven-plugin:nar-gnu-make,
 						com.github.maven-nar:nar-maven-plugin:nar-compile
 					</compile>
-					<process-classes>com.github.maven-nar:nar-maven-plugin:nar-gnu-process,
+					<process-classes>
+						com.github.maven-nar:nar-maven-plugin:nar-gnu-process,
 						com.github.maven-nar:nar-maven-plugin:nar-process-libraries
 					</process-classes>
-					<generate-test-sources>com.github.maven-nar:nar-maven-plugin:nar-prepare-package</generate-test-sources>
+					<generate-test-sources>
+						com.github.maven-nar:nar-maven-plugin:nar-test-unpack
+					</generate-test-sources>
 					<process-test-sources></process-test-sources>
 					<generate-test-resources></generate-test-resources>
-					<process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources
+					<process-test-resources>
+						org.apache.maven.plugins:maven-resources-plugin:testResources
 					</process-test-resources>
-					<test-compile>org.apache.maven.plugins:maven-compiler-plugin:testCompile
+					<test-compile>
+						org.apache.maven.plugins:maven-compiler-plugin:testCompile,
+						com.github.maven-nar:nar-maven-plugin:nar-testCompile
 					</test-compile>
-					<process-test-classes>com.github.maven-nar:nar-maven-plugin:nar-testCompile
+					<process-test-classes>
+						
 					</process-test-classes>
-					<test>org.apache.maven.plugins:maven-surefire-plugin:test,
+					<test>
+						org.apache.maven.plugins:maven-surefire-plugin:test,
 						com.github.maven-nar:nar-maven-plugin:nar-test
 					</test>
-					<prepare-package>com.github.maven-nar:nar-maven-plugin:nar-prepare-package
+					<prepare-package>
+						com.github.maven-nar:nar-maven-plugin:nar-prepare-package
 					</prepare-package>
-					<package>com.github.maven-nar:nar-maven-plugin:nar-package,
+					<package>
+						com.github.maven-nar:nar-maven-plugin:nar-package,
 						org.apache.maven.plugins:maven-jar-plugin:jar
 					</package>
 					<pre-integration-test></pre-integration-test>
-					<integration-test>com.github.maven-nar:nar-maven-plugin:nar-integration-test
+					<integration-test>
+						com.github.maven-nar:nar-maven-plugin:nar-integration-test
 					</integration-test>
 					<post-integration-test></post-integration-test>
 					<verify></verify>
-					<install>org.apache.maven.plugins:maven-install-plugin:install
+					<install>
+						org.apache.maven.plugins:maven-install-plugin:install
 					</install>
-					<deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy
+					<deploy>
+						org.apache.maven.plugins:maven-deploy-plugin:deploy
 					</deploy>
 				</phases>
 			</configuration>

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -70,17 +70,19 @@ allows you to build a jar file as well as nar files. The list below shows the se
     
     [[11]] {{{nar-gnu-process}nar-gnu-process}}
     
-    [[12]] {{{nar-testCompile}nar-testCompile}}
+    [[12]] {{{nar-test-unpack}nar-test-unpack}}
+    
+    [[13]] {{{nar-testCompile}nar-testCompile}}
    
-    [[13]] {{{nar-test}nar-test}}
+    [[14]] {{{nar-test}nar-test}}
     
-    [[14]] {{{nar-package}nar-package}}
+    [[15]] {{{nar-package}nar-package}}
     
-    [[15]] {{{nar-integration-test}nar-integration-test}}
+    [[16]] {{{nar-integration-test}nar-integration-test}}
     
-    [[16]] {{{install}install (standard maven goal)}}
+    [[17]] {{{install}install (standard maven goal)}}
     
-    [[17]] {{{deploy}deploy (standard maven goal)}}
+    [[18]] {{{deploy}deploy (standard maven goal)}}
 
 	[]
 	
@@ -120,8 +122,10 @@ This goal will download any further necessary nar files into the local repositor
 
 * {nar-unpack}
 
-	Since a nar file is of no use to any native compilation process, the nar-unpack goal unpacks the nar into
-the "nar/dependencies" subdirectory of the target directory.
+	Since a nar file is of no use to any native compilation process, the nar-unpack goal unpacks the nar into 
+the "nar" subdirectory of the target directory. The dependencies taken in account are those with the scopes compile, 
+provided and system which are the scopes needed for compilation.
+
         
 * {nar-gnu-configure} 
 
@@ -227,6 +231,12 @@ abstract classes in include files.>>
 * {nar-gnu-process}  
 
     Copies the gnu "install"-ed area into the NAR target area for testing and packing. 
+                
+* {nar-test-unpack}  
+
+    Unpacks the nar dependencies into the "test-nar" subdirectory of the target directory. The dependencies taken in 
+account are those with the scopes compile, provided, runtime, system and test which are the scopes needed for tests 
+compilation and executions.
                 
 * {nar-testCompile}
 

--- a/src/site/apt/lifecycle.apt
+++ b/src/site/apt/lifecycle.apt
@@ -35,21 +35,21 @@ standard maven goals) attached to them. The order is left to right, top to botto
 *------------------------+---------------------------------------------------------------------+ 
 | validate               | <<nar-validate>>                                                    |
 *------------------------+---------------------------------------------------------------------+ 
-| initialize             |                                                                     |
+| initialize             | <<nar-download>>                                                    |
 *------------------------+---------------------------------------------------------------------+ 
-| generate-sources       | <<nar-download>>                                                    |
+| generate-sources       | <<nar-unpack>>                                                      |
 *------------------------+---------------------------------------------------------------------+ 
-| process-sources        | <<nar-unpack>>, <<nar-gnu-configure>>                               |
+| process-sources        | <<nar-gnu-configure>>                                               |
 *------------------------+---------------------------------------------------------------------+ 
-| generate-resources     | <<nar-system-generate>>                                             |
+| generate-resources     | <<nar-system-generate>>, <<nar-vcproj>>                             |
 *------------------------+---------------------------------------------------------------------+ 
-| process-resources      | resources, <<nar-resources>>, <<nar-gnu-resources>>, <<nar-vcproj>> |
+| process-resources      | resources, <<nar-resources>>, <<nar-gnu-resources>>                 |
 *------------------------+---------------------------------------------------------------------+ 
 | compile                | compile, <<nar-javah>>, <<nar-gnu-make>>, <<nar-compile>>           |
 *------------------------+---------------------------------------------------------------------+ 
 | process-classes        | <<nar-gnu-process>>, <<nar-process-libraries>>                      |
 *------------------------+---------------------------------------------------------------------+ 
-| generate-test-sources  |                                                                     |
+| generate-test-sources  | <<nar-test-unpack>>                                                 |
 *------------------------+---------------------------------------------------------------------+ 
 | process-test-sources   |                                                                     |
 *------------------------+---------------------------------------------------------------------+ 
@@ -57,9 +57,9 @@ standard maven goals) attached to them. The order is left to right, top to botto
 *------------------------+---------------------------------------------------------------------+ 
 | process-test-resources | testResources                                                       |
 *------------------------+---------------------------------------------------------------------+ 
-| test-compile           | testCompile                                                         |
+| test-compile           | testCompile, <<nar-testCompile>>                                    |
 *------------------------+---------------------------------------------------------------------+ 
-| process-test-classes   | <<nar-testCompile>>                                                 |
+| process-test-classes   |                                                                     |
 *------------------------+---------------------------------------------------------------------+ 
 | test                   | test, <<nar-test>>                                                  |
 *------------------------+---------------------------------------------------------------------+ 


### PR DESCRIPTION
<b>Corrects the dependencies management:</b>
Redefines the goals where the dependencies are downloaded and unpack,
and avoid doing so several times.
- Phase initialize - goal nar-download : download all the project
dependencies in the local maven repository.
- Phase generate-sources - goal nar-unpack : unpack in the project
target folder (sub folder nar) the NAR files needed for compilation.
- Phase generate-test-sources - goal nar-test-unpack : unpack in the
project target folder (sub folder test-nar) the NAR files needed for
tests compilations, for tests executions, and for executions.

Plus some corrections concerning the way we use the dependencies and a bug correction (related to the closed issue #140 ), see the commit "Corrects the dependencies management." for more informations.

<b>Add integration tests for dependencies scopes.</b>
Add integration tests to test the use of the different scopes for dependencies, with a comment to explain the utility of each scope for NAR libraries (the comments are in the POM file of each library in the IT Test it0028). See the commit "Add integration tests for dependencies scopes." for more informations.
