### PR TITLE
Ccache

### DIFF
--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -182,8 +182,6 @@ public class NarCompileMojo
 
         task.setDecorateLinkerOptions(decorateLinkerOptions);
 
-        task.setDecorateLinkerOptions(decorateLinkerOptions);
-
         // subsystem
         SubsystemEnum subSystem = new SubsystemEnum();
         subSystem.setValue( library.getSubSystem() );

--- a/src/main/java/com/github/maven_nar/NarManager.java
+++ b/src/main/java/com/github/maven_nar/NarManager.java
@@ -141,7 +141,6 @@ public class NarManager
             if ( dash < 0 )
             {
 				aol = new AOL(classifier);
-				type = null;
             }
             else
             {
@@ -164,10 +163,7 @@ public class NarManager
 
             for ( int j = 0; j < classifiers.length; j++ )
             {
-                if ( artifactList != null )
-                {
                     artifactList.addAll( getAttachedNarDependencies( narArtifacts, classifiers[j] ));
-                }
             }
         }
         else

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -18,10 +18,10 @@
  * #L%
  */
 package com.github.maven_nar.cpptasks;
+
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
-
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
@@ -36,6 +36,8 @@ import com.github.maven_nar.cpptasks.types.DefineSet;
 import com.github.maven_nar.cpptasks.types.IncludePath;
 import com.github.maven_nar.cpptasks.types.SystemIncludePath;
 import com.github.maven_nar.cpptasks.types.UndefineArgument;
+
+
 /**
  * A compiler definition. compiler elements may be placed either as children of
  * a cc element or the project element. A compiler element with an id attribute
@@ -46,6 +48,7 @@ import com.github.maven_nar.cpptasks.types.UndefineArgument;
 public final class CompilerDef extends ProcessorDef {
     /** The source file sets. */
     private final Vector defineSets = new Vector();
+    private Boolean ccache = false;
     private Boolean exceptions;
     private Boolean rtti;
     private final Vector includePaths = new Vector();
@@ -80,6 +83,7 @@ public final class CompilerDef extends ProcessorDef {
         }
         addConfiguredProcessorArg(arg);
     }
+
     /**
      * Adds a compiler command-line arg.
      */
@@ -89,6 +93,7 @@ public final class CompilerDef extends ProcessorDef {
         }
         addConfiguredProcessorParam(param);
     }
+
     /**
      * Adds a defineset.
      */
@@ -101,6 +106,7 @@ public final class CompilerDef extends ProcessorDef {
         }
         defineSets.addElement(defs);
     }
+
     /**
      * Creates an include path.
      */
@@ -116,6 +122,7 @@ public final class CompilerDef extends ProcessorDef {
         includePaths.addElement(path);
         return path;
     }
+
     /**
      * Specifies precompilation prototype file and exclusions.
      *  
@@ -130,6 +137,7 @@ public final class CompilerDef extends ProcessorDef {
         precompileDefs.addElement(precomp);
         return precomp;
     }
+
     /**
      * Creates a system include path. Locations and timestamps of files located
      * using the system include paths are not used in dependency analysis.
@@ -179,6 +187,7 @@ public final class CompilerDef extends ProcessorDef {
         actives.copyInto(retval);
         return retval;
     }
+
     /**
      * Returns the compiler-specific include path.
      */
@@ -325,6 +334,7 @@ public final class CompilerDef extends ProcessorDef {
         }
         return warnings;
     }
+
     /**
      * Sets the default compiler adapter. Use the "name" attribute when the
      * compiler is a supported compiler.
@@ -342,6 +352,7 @@ public final class CompilerDef extends ProcessorDef {
             throw new BuildException(classname + " does not implement Compiler");
         }
     }
+
     /**
      * Enables or disables exception support.
      * 
@@ -383,6 +394,7 @@ public final class CompilerDef extends ProcessorDef {
         }
         this.multithreaded = booleanValueOf(multithreaded);
     }
+
     /**
      * Sets compiler type.
      * 
@@ -501,6 +513,7 @@ public final class CompilerDef extends ProcessorDef {
             throw new BuildException(ex);
         }
     }
+
     /**
      * Enumerated attribute with the values "none", "severe", "default",
      * "production", "diagnostic", and "aserror".
@@ -508,10 +521,12 @@ public final class CompilerDef extends ProcessorDef {
     public void setWarnings(WarningLevelEnum level) {
         warnings = level.getIndex();
     }
+
     /**
      * Sets optimization level.
      * 
-     * @param value optimization level
+     * @param value
+     *            optimization level
      */
     public void setOptimize(OptimizationEnum value) {
     	if (isReference()) {
@@ -523,6 +538,7 @@ public final class CompilerDef extends ProcessorDef {
     // FREEHEP
 	/**
 	 * List of source filenames without extensions
+     * 
 	 * @param asList
 	 */
 	public void setOrder(List<String> order) {
@@ -540,4 +556,12 @@ public final class CompilerDef extends ProcessorDef {
 	public void setToolPath(String path) {
 		toolPath = path;
 	}
+
+    public Boolean getCcache() {
+        return ccache;
+    }
+
+    public void setCcache(Boolean ccache) {
+        this.ccache = ccache;
+    }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompilerConfiguration.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompilerConfiguration.java
@@ -21,8 +21,8 @@ package com.github.maven_nar.cpptasks.compiler;
 import java.io.File;
 
 
-import org.apache.tools.ant.BuildException;
 
+import org.apache.tools.ant.BuildException;
 import com.github.maven_nar.cpptasks.CCTask;
 import com.github.maven_nar.cpptasks.CompilerParam;
 import com.github.maven_nar.cpptasks.DependencyInfo;
@@ -36,6 +36,7 @@ import com.github.maven_nar.cpptasks.VersionInfo;
 public final class CommandLineCompilerConfiguration
         implements
             CompilerConfiguration {
+    private boolean useCcache;
     private/* final */String[] args;
     private/* final */CommandLineCompiler compiler;
     private String[] endArgs;
@@ -56,14 +57,15 @@ public final class CommandLineCompilerConfiguration
     public CommandLineCompilerConfiguration(CommandLineCompiler compiler,
             String identifier, File[] includePath, File[] sysIncludePath,
             File[] envIncludePath, String includePathIdentifier, String[] args,
-            ProcessorParam[] params, boolean rebuild, String[] endArgs) {
+            ProcessorParam[] params, boolean rebuild, String[] endArgs, boolean useCcache) {
         this(compiler, identifier, includePath, sysIncludePath, envIncludePath,
-            includePathIdentifier, args, params, rebuild, endArgs, null);
+            includePathIdentifier, args, params, rebuild, endArgs, null, useCcache);
     }
+
     public CommandLineCompilerConfiguration(CommandLineCompiler compiler,
             String identifier, File[] includePath, File[] sysIncludePath,
             File[] envIncludePath, String includePathIdentifier, String[] args,
-            ProcessorParam[] params, boolean rebuild, String[] endArgs,String commandPath) {
+            ProcessorParam[] params, boolean rebuild, String[] endArgs,String commandPath, boolean useCcache) {
         if (compiler == null) {
             throw new NullPointerException("compiler");
         }
@@ -93,6 +95,7 @@ public final class CommandLineCompilerConfiguration
         } else {
             this.envIncludePath = (File[]) envIncludePath.clone();
         }
+        this.useCcache = useCcache;
         this.compiler = compiler;
         this.params = (ProcessorParam[]) params.clone();
         this.rebuild = rebuild;
@@ -243,5 +246,10 @@ public final class CommandLineCompilerConfiguration
     }
     public final String getCommandPath() {
         return this.commandPath;
+    }
+
+    public boolean isUseCcache()
+    {
+        return useCcache;
     }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/AbstractLdLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/AbstractLdLinker.java
@@ -114,7 +114,7 @@ public abstract class AbstractLdLinker extends CommandLineLinker {
                     String relPath = libdir.getAbsolutePath();
                     //File outputFile = task.getOutfile();
                     File currentDir = new File(".");
-                    if (currentDir != null && currentDir.getParentFile() != null) {
+                    if (currentDir.getParentFile() != null) {
                         relPath = CUtil.getRelativePath(
                         		currentDir.getParentFile().getAbsolutePath(), libdir);
                     }

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -123,6 +123,7 @@ NAR Configuration
     <rtti/>
     <optimize/>
     <multiThreaded/>
+    <ccache/>
     <defines>
       <define/>
     </defines>
@@ -409,6 +410,12 @@ the command line for compatible compilers/linkers. Default is false.
    
     Enables or disables generation of multithreaded code.
     Default value: false, except on Windows.
+    
+** {cpp ccache}
+
+    Enables or disables the use of ccache (https://ccache.samba.org/) for compilation. 
+    Ccache must be present on the system and available the path in the same way your compiler is.
+    Default value: false
    
 ** {cpp defines}
 

--- a/src/test/java/com/github/maven_nar/cpptasks/TestCCTask.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/TestCCTask.java
@@ -58,7 +58,7 @@ public final class TestCCTask
     CompilerConfiguration config1 = new CommandLineCompilerConfiguration(
         (GccCCompiler) GccCCompiler.getInstance(), "dummy",
         new File[0], new File[0], new File[0], "", new String[0],
-        new ProcessorParam[0], true, new String[0]);
+        new ProcessorParam[0], true, new String[0], false);
     TargetInfo target1 = new TargetInfo(config1, new File[] {new File(
         "src/foo.bar")}
                                         , null, new File("foo.obj"), true);
@@ -82,7 +82,7 @@ public final class TestCCTask
     CompilerConfiguration config1 = new CommandLineCompilerConfiguration(
         (GccCCompiler) GccCCompiler.getInstance(), "dummy",
         new File[0], new File[0], new File[0], "", new String[0],
-        new ProcessorParam[0], false, new String[0]);
+        new ProcessorParam[0], false, new String[0], false);
     //
     //    target doesn't need to be rebuilt
     //

--- a/src/test/java/com/github/maven_nar/cpptasks/compiler/TestCommandLineCompilerConfiguration.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/compiler/TestCommandLineCompilerConfiguration.java
@@ -42,13 +42,13 @@ public class TestCommandLineCompilerConfiguration
         return new CommandLineCompilerConfiguration(compiler, "dummy",
                 new File[0], new File[0], new File[0], "",
                 new String[]{"/Id:/gcc"}, new ProcessorParam[0], false,
-                new String[0]);
+                new String[0], false);
     }
     public void testConstructorNullCompiler() {
         try {
             new CommandLineCompilerConfiguration(null, "dummy", new File[0],
                     new File[0], new File[0], "", new String[0],
-                    new ProcessorParam[0], false, new String[0]);
+                    new ProcessorParam[0], false, new String[0], false);
             fail("Should throw exception for null compiler");
         } catch (NullPointerException ex) {
         }


### PR DESCRIPTION
Added support for compiling with ccache via a cpp property.

This change allows the nar maven plugin to compile using ccache:
(https://ccache.samba.org/)

It does this by adding a boolean property to the cpp config called ccache.
If this is true, the command is tweaked to call ccache with the compiler command.

Details:
 * Added boolean ccache maven parameter
 * Added ccache boolean flag to CompilerDef.
 * CommandLineCompiler tweaks the command if ccache in use.
 * CommandLineCompilerConfiguration passes useCcache to compiler compile method.
 * Existing unit tests use false for ccache.
 * Added some javadoc for getCompilerDef in Compiler.java
 * Updated configuration.apt with usage details.


There are also two commits containing a bit of clean up. Nothing major.

In the future this could possibly be converted to a compiler wrappers option to we can change things like distcc colourgcc too.