### PR TITLE
Remove the property final on the @Parameter attributes.

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -87,7 +87,7 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
    * Maximum number of Cores/CPU's to use. 0 means unlimited.
    */
   @Parameter
-  private final int maxCores = 0;
+  private int maxCores = 0;
 
   /**
    * Fail on compilation/linking error.

--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -84,46 +84,46 @@ public abstract class Compiler {
    * Include patterns for sources
    */
   @Parameter(required = true)
-  private final Set<String> includes = new HashSet<String>();
+  private Set<String> includes = new HashSet<String>();
 
   /**
    * Exclude patterns for sources
    */
   @Parameter(required = true)
-  private final Set<String> excludes = new HashSet<String>();
+  private Set<String> excludes = new HashSet<String>();
 
   /**
    * Include patterns for test sources
    */
   @Parameter(required = true)
-  private final Set<String> testIncludes = new HashSet<String>();
+  private Set<String> testIncludes = new HashSet<String>();
 
   /**
    * Exclude patterns for test sources
    */
   @Parameter(required = true)
-  private final Set<String> testExcludes = new HashSet<String>();
+  private Set<String> testExcludes = new HashSet<String>();
 
   @Parameter(defaultValue = "false", required = false)
-  private final boolean ccache = false;
+  private boolean ccache = false;
 
   /**
    * Compile with debug information.
    */
   @Parameter(required = true)
-  private final boolean debug = false;
+  private boolean debug = false;
 
   /**
    * Enables generation of exception handling code.
    */
   @Parameter(defaultValue = "true", required = true)
-  private final boolean exceptions = true;
+  private boolean exceptions = true;
 
   /**
    * Enables run-time type information.
    */
   @Parameter(defaultValue = "true", required = true)
-  private final boolean rtti = true;
+  private boolean rtti = true;
 
   /**
    * Sets optimization. Possible choices are: "none", "size", "minimal",
@@ -131,14 +131,14 @@ public abstract class Compiler {
    * "unsafe".
    */
   @Parameter(defaultValue = "none", required = true)
-  private final String optimize = "none";
+  private String optimize = "none";
 
   /**
    * Enables or disables generation of multi-threaded code. Default value:
    * false, except on Windows.
    */
   @Parameter(required = true)
-  private final boolean multiThreaded = false;
+  private boolean multiThreaded = false;
 
   /**
    * Defines

--- a/src/main/java/com/github/maven_nar/Java.java
+++ b/src/main/java/com/github/maven_nar/Java.java
@@ -44,7 +44,7 @@ public class Java {
    * Add Java includes to includepath
    */
   @Parameter(required = true)
-  private final boolean include = false;
+  private boolean include = false;
 
   /**
    * Java Include Paths, relative to a derived ${java.home}. Defaults to:
@@ -58,7 +58,7 @@ public class Java {
    * Add Java Runtime to linker
    */
   @Parameter(required = true)
-  private final boolean link = false;
+  private boolean link = false;
 
   /**
    * Relative path from derived ${java.home} to the java runtime to link with
@@ -72,7 +72,7 @@ public class Java {
    * Name of the runtime
    */
   @Parameter(defaultValue = "jvm")
-  private final String runtime = "jvm";
+  private String runtime = "jvm";
 
   private AbstractCompileMojo mojo;
 

--- a/src/main/java/com/github/maven_nar/Javah.java
+++ b/src/main/java/com/github/maven_nar/Javah.java
@@ -55,20 +55,20 @@ public class Javah {
    * Javah command to run.
    */
   @Parameter(defaultValue = "javah")
-  private final String name = "javah";
+  private String name = "javah";
 
   /**
    * Add boot class paths. By default none.
    */
   @Parameter
-  private final List/* <File> */bootClassPaths = new ArrayList();
+  private List/* <File> */bootClassPaths = new ArrayList();
 
   /**
    * Add class paths. By default the classDirectory directory is included and
    * all dependent classes.
    */
   @Parameter
-  private final List/* <File> */classPaths = new ArrayList();
+  private List/* <File> */classPaths = new ArrayList();
 
   /**
    * The target directory into which to generate the output.
@@ -86,26 +86,26 @@ public class Javah {
    * The set of files/patterns to include Defaults to "**\/*.class"
    */
   @Parameter
-  private final Set includes = new HashSet();
+  private Set includes = new HashSet();
 
   /**
    * A list of exclusion filters.
    */
   @Parameter
-  private final Set excludes = new HashSet();
+  private Set excludes = new HashSet();
 
   /**
    * A list of class names e.g. from java.sql.* that are also passed to javah.
    */
   @Parameter
-  private final Set extraClasses = new HashSet();
+  private Set extraClasses = new HashSet();
 
   /**
    * The granularity in milliseconds of the last modification date for testing
    * whether a source needs recompilation
    */
   @Parameter(defaultValue = "0", required = true)
-  private final int staleMillis = 0;
+  private int staleMillis = 0;
 
   /**
    * The directory to store the timestampfile for the processed aid files.

--- a/src/main/java/com/github/maven_nar/Lib.java
+++ b/src/main/java/com/github/maven_nar/Lib.java
@@ -52,7 +52,7 @@ public class Lib {
    * Type of linking for this library
    */
   @Parameter(defaultValue = "shared", required = true)
-  private final String type = Library.SHARED;
+  private String type = Library.SHARED;
 
   /**
    * Location for this library

--- a/src/main/java/com/github/maven_nar/Library.java
+++ b/src/main/java/com/github/maven_nar/Library.java
@@ -49,59 +49,59 @@ public class Library implements Executable {
    * Defaults to "shared".
    */
   @Parameter
-  private final String type = SHARED;
+  private String type = SHARED;
 
   /**
    * Type of subsystem to generate: "gui", "console", "other". Defaults to
    * "console".
    */
   @Parameter
-  private final String subSystem = "console";
+  private String subSystem = "console";
 
   /**
    * Link with stdcpp if necessary Defaults to true.
    */
   @Parameter(defaultValue = "true")
-  private final boolean linkCPP = true;
+  private boolean linkCPP = true;
 
   /**
    * Link with fortran runtime if necessary Defaults to false.
    */
   @Parameter
-  private final boolean linkFortran = false;
+  private boolean linkFortran = false;
 
   /**
    * Link with fortran startup, so that the gcc linker can find the "main" of
    * fortran. Defaults to false.
    */
   @Parameter
-  private final boolean linkFortranMain = false;
+  private boolean linkFortranMain = false;
 
   /**
    * If specified will create the NarSystem class with methods to load a JNI
    * library.
    */
   @Parameter
-  private final String narSystemPackage = null;
+  private String narSystemPackage = null;
 
   /**
    * Name of the NarSystem class
    */
   @Parameter(defaultValue = "NarSystem", required = true)
-  private final String narSystemName = "NarSystem";
+  private String narSystemName = "NarSystem";
 
   /**
    * The target directory into which to generate the output.
    */
   @Parameter(defaultValue = "${project.build.dir}/nar/nar-generated", required = true)
-  private final String narSystemDirectory = "nar-generated";
+  private String narSystemDirectory = "nar-generated";
 
   /**
    * When true and if type is "executable" run this executable. Defaults to
    * false;
    */
   @Parameter
-  private final boolean run = false;
+  private boolean run = false;
 
   /**
    * Arguments to be used for running this executable. Defaults to empty list.
@@ -109,7 +109,7 @@ public class Library implements Executable {
    * and type=executable.
    */
   @Parameter
-  private final List/* <String> */args = new ArrayList();
+  private List/* <String> */args = new ArrayList();
 
   @Override
   public final List/* <String> */getArgs() {

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -69,13 +69,13 @@ public class Linker {
    * Enables or disables incremental linking.
    */
   @Parameter(required = true)
-  private final boolean incremental = false;
+  private boolean incremental = false;
 
   /**
    * Enables or disables the production of a map file.
    */
   @Parameter(required = true)
-  private final boolean map = false;
+  private boolean map = false;
 
   /**
    * Options for the linker Defaults to Architecture-OS-Linker specific values.

--- a/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
@@ -264,7 +264,7 @@ public class NarIntegrationTestMojo extends AbstractDependencyMojo {
    * has errors.
    */
   @Parameter(property = "surefire.printSummary", defaultValue = "true")
-  private final boolean printSummary = true;
+  private boolean printSummary = true;
 
   /**
    * Selects the formatting for the test report to be generated. Can be set as
@@ -358,7 +358,7 @@ public class NarIntegrationTestMojo extends AbstractDependencyMojo {
    * @since 2.1.3
    */
   @Parameter
-  private final Map environmentVariables = new HashMap();
+  private Map environmentVariables = new HashMap();
 
   /**
    * Command line working directory.
@@ -464,7 +464,7 @@ public class NarIntegrationTestMojo extends AbstractDependencyMojo {
    * @since 2.2
    */
   @Parameter(property = "trimStackTrace", defaultValue = "true")
-  private final boolean trimStackTrace = true;
+  private boolean trimStackTrace = true;
 
   /**
    * Creates the artifact
@@ -513,7 +513,7 @@ public class NarIntegrationTestMojo extends AbstractDependencyMojo {
    * @since 2.4.3
    */
   @Parameter(property = "surefire.useManifestOnlyJar", defaultValue = "true")
-  private final boolean useManifestOnlyJar = true;
+  private boolean useManifestOnlyJar = true;
 
   /**
    * By default, Surefire enables JVM assertions for the execution of your test

--- a/src/main/java/com/github/maven_nar/SysLib.java
+++ b/src/main/java/com/github/maven_nar/SysLib.java
@@ -43,7 +43,7 @@ public class SysLib {
    * Type of linking for this system library
    */
   @Parameter(defaultValue = "shared")
-  private final String type = Library.SHARED;
+  private String type = Library.SHARED;
 
   public final SystemLibrarySet getSysLibSet(final Project antProject) throws MojoFailureException {
     if (this.name == null) {

--- a/src/main/java/com/github/maven_nar/Test.java
+++ b/src/main/java/com/github/maven_nar/Test.java
@@ -36,27 +36,27 @@ public class Test implements Executable {
    * Name of the test to create
    */
   @Parameter(required = true)
-  private final String name = null;
+  private String name = null;
 
   /**
    * Type of linking used for this test Possible choices are: "shared" or
    * "static". Defaults to "shared".
    */
   @Parameter(defaultValue = "shared")
-  private final String link = Library.SHARED;
+  private String link = Library.SHARED;
 
   /**
    * When true run this test. Defaults to true;
    */
   @Parameter(defaultValue = "true")
-  private final boolean run = true;
+  private boolean run = true;
 
   /**
    * Arguments to be used for running this test. Defaults to empty list. This
    * option is only used if run=true.
    */
   @Parameter
-  private final List/* <String> */args = new ArrayList();
+  private List/* <String> */args = new ArrayList();
 
   @Override
   public final List/* <String> */getArgs() {


### PR DESCRIPTION
In a pom I defined a library type as static, and during the execution of
the plugin the library type was set to shared which is the default
value.
By removing the keyword "final" on the attribute "type" in the class
Library, the build was back to normal.
The attribute "type" has the annotation @Parameter and thus its value 
is normally set from the pom by maven, but the property final seemed to 
prevent that.

So I removed the keyword "final" on all the @Parameter attributes.