### PR TITLE
A fix to "NAR: Compile failed: Output filename conflict"

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
@@ -101,7 +101,7 @@ public final class TargetMatcher implements FileVisitor {
         // see if the same output file has already been registered
         //
         StringBuffer sb = new StringBuffer( FilenameUtils.removeExtension(outputFileName) );
-        sb.append( fullPath.getAbsolutePath().hashCode() + ".o" );
+        sb.append( fullPath.getAbsolutePath().hashCode() + "." + FilenameUtils.getExtension(outputFileName) );
         String newOutputFileName = sb.toString();
 
         final TargetInfo previousTarget = this.targets.get(newOutputFileName);

--- a/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Vector;
 
 import org.apache.tools.ant.BuildException;
+import org.apache.commons.io.FilenameUtils;
 
 import com.github.maven_nar.cpptasks.compiler.LinkerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.ProcessorConfiguration;
@@ -99,10 +100,14 @@ public final class TargetMatcher implements FileVisitor {
         //
         // see if the same output file has already been registered
         //
-        final TargetInfo previousTarget = this.targets.get(outputFileName);
+        StringBuffer sb = new StringBuffer( FilenameUtils.removeExtension(outputFileName) );
+        sb.append( fullPath.getAbsolutePath().hashCode() + ".o" );
+        String newOutputFileName = sb.toString();
+
+        final TargetInfo previousTarget = this.targets.get(newOutputFileName);
         if (previousTarget == null) {
-          this.targets.put(outputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
-              this.outputDir, outputFileName), selectedCompiler.getRebuild()));
+          this.targets.put(newOutputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
+              this.outputDir, newOutputFileName), selectedCompiler.getRebuild()));
         } else {
           if (!previousTarget.getSources()[0].equals(this.sourceFiles[0])) {
             final StringBuffer builder = new StringBuffer("Output filename conflict: ");

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
@@ -208,4 +208,8 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
     }
     return false;
   }
+
+  public final String getOutputSuffix() {
+    return this.outputSuffix;
+  }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -220,7 +220,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
         commandline[index++] = "-o";
 
         StringBuffer sb = new StringBuffer( FilenameUtils.getBaseName(sourceFiles[j]) );
-        sb.append( sourceFiles[j].hashCode() + ".o" );
+        sb.append( sourceFiles[j].hashCode() + getOutputSuffix());
         final String newOutputFileName = sb.toString();
 
         commandline[index++] = newOutputFileName;


### PR DESCRIPTION
I generally follow #141 to insert a `hash(absoluteSourceFilePath)` between the object file basename and its extension. I found it quite difficult to mirror the folder structure of the source file into the object file (like discussed in #162 ), because the `compile` interface in `src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java` make the output file invisiable to `commandlinecompiler`.

What #141 seemed to miss is that c++ compiler should compile one source into one object file by one command. But the original code seems to feed several sources to one command and it makes `-o` to several objects invalid.

It's a quick and dirty solution to the conflict problem however may works.