### PR TITLE
A fix to "NAR: Compile failed: Output filename conflict"

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -37,6 +37,7 @@ import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.Environment;
+import org.apache.commons.io.FilenameUtils;
 
 import com.github.maven_nar.cpptasks.compiler.CompilerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.LinkType;
@@ -1169,6 +1170,9 @@ public class CCTask extends Task {
         // breaks multi compilers like resource/midl if same basename as c/cpp
         // so moved the comparison to above to avoid trimming the extension if
         // there is no order, which half fixes the issue.
+
+        f0 = FilenameUtils.getBaseName(f0);
+        f1 = FilenameUtils.getBaseName(f1);
 
         f0 = f0.lastIndexOf('.') < 0 ? f0 : f0.substring(0, f0.lastIndexOf('.'));
         f1 = f1.lastIndexOf('.') < 0 ? f1 : f1.substring(0, f1.lastIndexOf('.'));

--- a/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Vector;
 
 import org.apache.tools.ant.BuildException;
+import org.apache.commons.io.FilenameUtils;
 
 import com.github.maven_nar.cpptasks.compiler.LinkerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.ProcessorConfiguration;
@@ -99,10 +100,14 @@ public final class TargetMatcher implements FileVisitor {
         //
         // see if the same output file has already been registered
         //
-        final TargetInfo previousTarget = this.targets.get(outputFileName);
+        StringBuffer sb = new StringBuffer(FilenameUtils.removeExtension(outputFileName));
+        sb.append("." + fullPath.getAbsolutePath().hashCode() + "." + FilenameUtils.getExtension(outputFileName) );
+        String newOutputFileName = sb.toString();
+
+        final TargetInfo previousTarget = this.targets.get(newOutputFileName);
         if (previousTarget == null) {
-          this.targets.put(outputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
-              this.outputDir, outputFileName), selectedCompiler.getRebuild()));
+          this.targets.put(newOutputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
+              this.outputDir, newOutputFileName), selectedCompiler.getRebuild()));
         } else {
           if (!previousTarget.getSources()[0].equals(this.sourceFiles[0])) {
             final StringBuffer builder = new StringBuffer("Output filename conflict: ");

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
@@ -208,4 +208,8 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
     }
     return false;
   }
+
+  public final String getOutputSuffix() {
+    return this.outputSuffix;
+  }
 }


### PR DESCRIPTION
Sorry for duplicate pr

This pr mainly involves inserting a `absoluteSourceFilePath.hashCode()` between the object file basename and its extension, trying to solve the "NAR: Compile failed: Output filename conflict" problem.

For example, an object fiie of `HelloWorldJNI.o` is transformed into `HelloWorldJNI.1824699243.o` (in `src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java`) to avoid output filename conflict. Such transformation requires an additional `-o` option (`/Fo` in MSVC) in commandlinecompiler which is introduced in `src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java`.

In previous nar-maven-plugin, several source files are compiled in one commandline. For example e `gcc a.c b.c c.c`. Since it relies on `gcc` to output `a.o b.o c.o`, to output `a.hashed.o b.hashed.o c.hashed.o`, I split it into 3 commands.

To make the compileOrder works (it0018-fortran), the comparison function on outputfilename extracts the basename (as `src/main/java/com/github/maven_nar/cpptasks/CCTask.java`)

Could anyone advise on this, since I am not sure about whether it is a good change.