### PR TITLE
System.mapLibraryName() changed in JDK 7 on OS X

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -55,7 +55,7 @@ public class GccLinker extends AbstractLdLinker {
       false, null);
   private static final GccLinker machDllLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".dylib", false,
       null);
-  private static final GccLinker machJNILinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".jnilib", false,
+  private static final GccLinker machJNILinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".dylib", false,
       null);
   // FREEHEP added dllLinker for windows
   private static final GccLinker dllLinker = new GccLinker("gcc", objFiles, discardFiles, "", ".dll", false, null);

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -59,7 +59,7 @@ public class GppLinker extends AbstractLdLinker {
   private static final GppLinker machPluginLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib",
       ".bundle", false, null);
   // FREEHEP
-  private static final GppLinker machJNILinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".jnilib",
+  private static final GppLinker machJNILinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".dylib",
       false, null);
   // FREEHEP added dllLinker for windows
   private static final GppLinker dllLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "", ".dll", false, null);


### PR DESCRIPTION
The generated NarSystem.loadLibrary() uses System.mapLibraryName() to
search for the JNI library.  In JDK 7 on OS X, System.mapLibraryName()
switched from a file extension of .jnilib to .dylib so OS X linking needs
the corresponding change.