### PR TITLE
Do not check non-jar or non-nar artefacts for NarInfo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,11 @@
       <artifactId>xml-apis</artifactId>
       <version>1.3.04</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -247,6 +247,11 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
       return null;
     }
 
+    if (!dependency.getType().equals("jar") && !dependency.getType().equals("nar")) {
+       getLog().debug("Skipping unreadable artifact: " + file);
+       return null;
+    }
+
     JarFile jar = null;
     try {
       jar = new JarFile(file);

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -20,11 +20,16 @@
 package com.github.maven_nar;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.jar.JarFile;
+import java.util.zip.ZipException;
+import java.util.zip.ZipInputStream;
+import org.apache.commons.io.IOUtils;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -247,9 +252,17 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
       return null;
     }
 
-    if (!dependency.getType().equals("jar") && !dependency.getType().equals("nar")) {
-       getLog().debug("Skipping unreadable artifact: " + file);
-       return null;
+    ZipInputStream zipStream = null;
+    try {
+      zipStream = new ZipInputStream(new FileInputStream(file));
+      if (zipStream.getNextEntry() == null) {
+        getLog().debug("Skipping unreadable artifact: " + file);
+        return null;
+      }
+    } catch (IOException e) {
+      throw new MojoExecutionException("Error while testing for zip file " + file, e);
+    } finally {
+      IOUtils.closeQuietly(zipStream);
     }
 
     JarFile jar = null;
@@ -266,13 +279,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     } catch (final IOException e) {
       throw new MojoExecutionException("Error while reading " + file, e);
     } finally {
-      if (jar != null) {
-        try {
-          jar.close();
-        } catch (final IOException e) {
-          // ignore
-        }
-      }
+      IOUtils.closeQuietly(jar);
     }
   }
 


### PR DESCRIPTION
During the nar-download phase the plugin hunts for Nar dependencies. It does this by opening each dependency artefact using the jar application and looking for NarInfo. If any dependencies are unreadable by jar a ZIP exception is generated. This pull request adds as explicit check that each artefact is of type jar or nar prior to passing to the jar application. If the check fails a log message is generated and getNarInfo() returns null, forcing  getNarArtifacts() to move onto the next artefact.
