### PR TITLE
Update to resolve issue with integration-test from snapshot

### DIFF
--- a/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
+++ b/src/main/java/com/github/maven_nar/NarIntegrationTestMojo.java
@@ -907,7 +907,10 @@ public class NarIntegrationTestMojo extends AbstractDependencyMojo {
           final String binding = binding2;
           if (!binding.equals(Library.STATIC)) {
             final File depLibPathEntry = getLayout().getLibDirectory(getUnpackDirectory(), dependency.getArtifactId(),
-                dependency.getVersion(), getAOL().toString(), binding);
+                dependency.getBaseVersion(), getAOL().toString(), binding);
+                //dependency.getVersion() calls the maven super class, which is not used when
+            	//unpacking the NarDependencies in AbstractDependencyMojo.  This causes
+            	//the path to not exist and not be added to the library path.
             if (depLibPathEntry.exists()) {
               getLog().debug("Adding dependency directory to java.library.path: " + depLibPathEntry);
               if (javaLibraryPath.length() > 0) {


### PR DESCRIPTION
artifacts.  Updated the path logic to be consistent with
AbstractDependencyMojo.

I had an issue with a JNI nar artifact that depended on a shared library nar artifact.  When I ran with the locally installed version, the integration-test phase worked fine.  When I deployed the shared library artifact and downloaded the dependency, the integration-test failed with the dependencies not being added.

I tracked the issue down to the version being used to add the dependency.   This PR updates the NarIntegrationTestMojo dependency to be consistent with the version used in the AbstractDependencyMojo.

An example is below.

POM dependency.

```
                 <dependency>
                        <groupId>my.group</groupId>
                        <artifactId>shared-library</artifactId>
                        <version>1.0-SNAPSHOT</version>
                        <type>nar</type>
                </dependency>
```

AbstractDependencyMojo unpacks it here:

```
target/test-nar/shared-library-1.0-SNAPSHOT-x86_64-MacOSX-gpp-shared/lib/x86_64-MacOSX-gpp/shared
```

NarIntegrationTestMojo tries to find it here:

```
target/test-nar/shared-library-1.0-20150908.175802-15-x86_64-MacOSX-gpp-shared/lib/x86_64-MacOSX-gpp/shared
```

because it uses the Maven super class method version.  That file doesn't exist and the library path is not modified.  This update uses the getBaseVersion method instead.


