### PR TITLE
Rework after last set of merges, Additional MSVC features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,11 +249,6 @@
       <artifactId>xml-apis</artifactId>
       <version>1.3.04</version>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.4</version>
-    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/github/maven_nar/Executable.java
+++ b/src/main/java/com/github/maven_nar/Executable.java
@@ -27,6 +27,8 @@ import java.util.List;
 public interface Executable {
 
   List/* <String> */getArgs();
+  String getBinding(NarArtifact dependency);
 
   boolean shouldRun();
+  
 }

--- a/src/main/java/com/github/maven_nar/Library.java
+++ b/src/main/java/com/github/maven_nar/Library.java
@@ -111,9 +111,27 @@ public class Library implements Executable {
   @Parameter
   private List/* <String> */args = new ArrayList();
 
+  /**
+   * List of artifact:binding  for type of dependency to link against when there is a choice.
+   */
+  @Parameter
+  private List<String> dependencyBindings = new ArrayList<String>();
+  
   @Override
   public final List/* <String> */getArgs() {
     return this.args;
+  }
+
+  public String getBinding(NarArtifact dependency) {
+    for (String dependBind : dependencyBindings ) {
+      String[] pair = dependBind.trim().split( ":", 2 );
+      if( dependency.getArtifactId().equals(pair[0].trim()) ){
+        String result = pair[1].trim();
+        if( !result.isEmpty() )
+          return result;
+      }
+    }
+    return null;
   }
 
   public final String getNarSystemDirectory() {

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -517,6 +517,8 @@ public class Linker {
     }
 
     if (version == null) {
+      if(!err.toString().isEmpty())
+        mojo.getLog().debug("linker returned error stream: " + err.toString() );
       throw new MojoFailureException("Cannot deduce version number from: " + out.toString());
     }
     return version;

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Comparator;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -39,6 +40,7 @@ public class Msvc {
 
   private File windowsHome;
   private String toolPathWindowsSDK;
+  private String versionPathWindowsSDK = "";
   private String toolPathLinker;
 
   private boolean addIncludePath(final CCTask task, final File home, final String subDirectory)
@@ -76,10 +78,6 @@ public class Msvc {
     return false;
   }
 
-  public int compareVersion(final String version1, final String version2) {
-    return version1.replace(".", "").compareTo(version2.replace(".", ""));
-  }
-
   public void configureCCTask(final CCTask task) throws MojoExecutionException {
     final String os = mojo.getOS();
     if (os.equals(OS.WINDOWS)) {
@@ -88,8 +86,10 @@ public class Msvc {
       if (compareVersion(this.windowsSdkVersion, "7.1A") <= 0) {
         addIncludePath(task, this.windowsSdkHome, "include");
       } else {
-        addIncludePath(task, this.windowsSdkHome, "include/shared");
-        addIncludePath(task, this.windowsSdkHome, "include/um");
+        addIncludePath(task, this.windowsSdkHome, "include" + versionPathWindowsSDK + "/ucrt");
+        addIncludePath(task, this.windowsSdkHome, "include" + versionPathWindowsSDK + "/um");
+        addIncludePath(task, this.windowsSdkHome, "include" + versionPathWindowsSDK + "/shared");
+        addIncludePath(task, this.windowsSdkHome, "include" + versionPathWindowsSDK + "/winrt");
       }
       task.addEnv(getPathVariable());
       // TODO: supporting running with clean environment - addEnv sets
@@ -131,17 +131,24 @@ public class Msvc {
         sdkArch = "x64";
       }
       // 6 lib ?+ lib/x86 or lib/x64
-      if (compareVersion(this.windowsSdkVersion, "8.0") < 0) { 
+      if (compareVersion(this.windowsSdkVersion, "8.0") < 0) {
         if ("x86".equals(arch)) {
           linker.addLibraryDirectory(this.windowsSdkHome, "lib");
         } else {
           linker.addLibraryDirectory(this.windowsSdkHome, "lib/" + sdkArch);
         }
       } else if (compareVersion(this.windowsSdkVersion, "8.0") == 0) {
-        linker.addLibraryDirectory(this.windowsSdkHome, "Lib/Win8/um/" + sdkArch);
+        linker.addLibraryDirectory(this.windowsSdkHome, "Lib/Win8/um/" + sdkArch); // 8+
       } else {
-        linker.addLibraryDirectory(this.windowsSdkHome, "Lib/Winv6.3/um/" + sdkArch);
+        linker.addLibraryDirectory(this.windowsSdkHome, "Lib/Winv6.3/um/" + sdkArch); // win
+                                                                                      // 8
+                                                                                      // sdk
+                                                                                      // compatible
+                                                                                      // with
+                                                                                      // XP
       }
+      linker.addLibraryDirectory(this.windowsSdkHome, "Lib" + versionPathWindowsSDK + "/ucrt/" + sdkArch); // 10+
+      linker.addLibraryDirectory(this.windowsSdkHome, "Lib" + versionPathWindowsSDK + "/um/" + sdkArch); // 10+
     }
   }
 
@@ -187,7 +194,8 @@ public class Msvc {
     // 32bit - force 32 on 64bit mojo(x86 / x86_amd64)
     // match mojo - os x86 is as above; os x64 mojo (x86 / amd64)
 
-    // Cross tools first if necessary, platform tools second, more generic tools later
+    // Cross tools first if necessary, platform tools second, more generic tools
+    // later
     if (!osArchitecture.equals(mojoArchitecture) && !matchMojo) {
       if (!addPath(this.home, "VC/bin/" + osArchitecture + "_" + mojoArchitecture)) {
         throw new MojoExecutionException("Unable to find compiler for architecture " + mojoArchitecture + ".\n"
@@ -261,8 +269,8 @@ public class Msvc {
         // able to acccess - HKLM\SOFTWARE\Microsoft\Visual
         // Studio\Major.Minor:InstallDir
       }
-      mojo.getLog().debug(
-          String.format(" VisualStudio %1s (%2s) found %3s ", this.version, internalVersion, this.home));
+      mojo.getLog()
+          .debug(String.format(" VisualStudio %1s (%2s) found %3s ", this.version, internalVersion, this.home));
     } else {
       this.version = "";
       File home = null;
@@ -279,7 +287,8 @@ public class Msvc {
               this.version = version;
               this.home = commonToolsDirectory.getParentFile().getParentFile();
               mojo.getLog().debug(
-                  String.format(" VisualStudio %1s (%2s) found %3s ", this.version, matcher.group(1) + matcher.group(2), this.home));
+                  String.format(" VisualStudio %1s (%2s) found %3s ", this.version,
+                      matcher.group(1) + matcher.group(2), this.home));
             }
           }
         }
@@ -297,7 +306,8 @@ public class Msvc {
         if (m.find()) {
           this.version = m.group(1);
           mojo.getLog().debug(
-              String.format(" VisualStudio Not found but link runs and reports version %1s (%2s)", this.version, m.group(0)));
+              String.format(" VisualStudio Not found but link runs and reports version %1s (%2s)", this.version,
+                  m.group(0)));
         } else {
           throw new MojoExecutionException(
               "msvc.version not specified and no VS<Version>COMNTOOLS environment variable can be found");
@@ -325,19 +335,50 @@ public class Msvc {
               if (kitVersion.charAt(0) == 'v') {
                 kitVersion = kitVersion.substring(1);
               }
-              mojo.getLog().debug(String.format(" WindowSDK %1s found %2s",kitVersion,kitDirectory.getAbsolutePath()));
-              if (kitVersion.matches("\\d+\\.\\d+[A-Z]?")) {
+              mojo.getLog()
+                  .debug(String.format(" WindowSDK %1s found %2s", kitVersion, kitDirectory.getAbsolutePath()));
+              if (kitVersion.matches("\\d+\\.\\d+?[A-Z]?")) { // windows 8/8.1
+                                                              // SDK
                 if (this.windowsSdkVersion.length() == 0) {
                   if (compareVersion(kitVersion, maxVersion) > 0) {
                     maxVersion = kitVersion;
                     home = kitDirectory;
                   }
                 } else {
-                  // TODO: is it acceptable to be sloppy - msvc installs 'A' version, windows platform sdk installs more complete
-                  // if (this.windowsSdkVersion.startsWith(kitVersion)) {  
+                  // TODO: is it acceptable to be sloppy - msvc installs 'A'
+                  // version, windows platform sdk installs more complete
+                  // if (this.windowsSdkVersion.startsWith(kitVersion)) {
                   if (kitVersion.equals(this.windowsSdkVersion)) {
                     maxVersion = this.windowsSdkVersion;
                     home = kitDirectory;
+                  }
+                }
+              }
+              if (kitVersion.matches("\\d+?")) { // windows 10 SDK supports
+                                                 // multiple installs
+                home = kitDirectory;
+                final File[] kitVersionDirectories = new File(kitDirectory, "Include").listFiles();
+                for (final File kitVersionDirectory : kitVersionDirectories) {
+                  mojo.getLog().debug(String.format(" KitDir %1s", kitVersionDirectory.getAbsolutePath()));
+                  if (new File(kitVersionDirectory, "um").exists()) {
+                    String kitSpecificVersion = kitVersionDirectory.getName();
+                    if (this.windowsSdkVersion.length() == 0 || kitVersion.equals(this.windowsSdkVersion)) { // unspecified
+                                                                                                             // or
+                                                                                                             // generic
+                                                                                                             // 10
+                      // find the max version available.
+                      mojo.getLog().debug(String.format(" KitVer %1s, maxVer %2s", kitSpecificVersion, maxVersion));
+                      if (compareVersion(kitSpecificVersion, maxVersion) > 0) {
+                        maxVersion = kitSpecificVersion;
+                        versionPathWindowsSDK = "/" + maxVersion;
+                      }
+                    } else {
+                      // find the specific version
+                      if (kitVersion.equals(this.windowsSdkVersion)) {
+                        maxVersion = kitSpecificVersion;
+                        versionPathWindowsSDK = "/" + maxVersion;
+                      }
+                    }
                   }
                 }
               }
@@ -350,10 +391,10 @@ public class Msvc {
       this.windowsSdkHome = home;
     }
     if (maxVersion.length() == 0) {
-      throw new MojoExecutionException("msvc.windowsSdkVersion not specified and versions can be found");
+      throw new MojoExecutionException("msvc.windowsSdkVersion not specified and versions cannot be found");
     }
     this.windowsSdkVersion = maxVersion;
-    mojo.getLog().debug(String.format(" Using WindowSDK %1s found %2s",this.windowsSdkVersion,this.windowsSdkHome));
+    mojo.getLog().debug(String.format(" Using WindowSDK %1s found %2s", this.windowsSdkVersion, this.windowsSdkHome));
   }
 
   public void setMojo(final AbstractNarMojo mojo) throws MojoFailureException, MojoExecutionException {
@@ -368,13 +409,157 @@ public class Msvc {
     return this.home + "\n" + this.windowsSdkHome;
   }
 
-  public String getToolPath() {return this.toolPathLinker;}
-  public String getSDKToolPath() {return this.toolPathWindowsSDK;}
+  public String getToolPath() {
+    return this.toolPathLinker;
+  }
+
+  public String getSDKToolPath() {
+    return this.toolPathWindowsSDK;
+  }
+
   public void setToolPath(CompilerDef compilerDef, String name) {
     if ("res".equals(name) || "mc".equals(name) || "idl".equals(name)) {
       compilerDef.setToolPath(this.toolPathWindowsSDK);
     } else {
       compilerDef.setToolPath(this.toolPathLinker);
+    }
+  }
+
+  public int compareVersion(Object o1, Object o2) {
+    String version1 = (String) o1;
+    String version2 = (String) o2;
+
+    VersionTokenizer tokenizer1 = new VersionTokenizer(version1);
+    VersionTokenizer tokenizer2 = new VersionTokenizer(version2);
+
+    int number1 = 0, number2 = 0;
+    String suffix1 = "", suffix2 = "";
+
+    while (tokenizer1.MoveNext()) {
+      if (!tokenizer2.MoveNext()) {
+        do {
+          number1 = tokenizer1.getNumber();
+          suffix1 = tokenizer1.getSuffix();
+          if (number1 != 0 || suffix1.length() != 0) {
+            // Version one is longer than number two, and non-zero
+            return 1;
+          }
+        } while (tokenizer1.MoveNext());
+
+        // Version one is longer than version two, but zero
+        return 0;
+      }
+
+      number1 = tokenizer1.getNumber();
+      suffix1 = tokenizer1.getSuffix();
+      number2 = tokenizer2.getNumber();
+      suffix2 = tokenizer2.getSuffix();
+
+      if (number1 < number2) {
+        // Number one is less than number two
+        return -1;
+      }
+      if (number1 > number2) {
+        // Number one is greater than number two
+        return 1;
+      }
+
+      boolean empty1 = suffix1.length() == 0;
+      boolean empty2 = suffix2.length() == 0;
+
+      if (empty1 && empty2)
+        continue; // No suffixes
+      if (empty1)
+        return 1; // First suffix is empty (1.2 > 1.2b)
+      if (empty2)
+        return -1; // Second suffix is empty (1.2a < 1.2)
+
+      // Lexical comparison of suffixes
+      int result = suffix1.compareTo(suffix2);
+      if (result != 0)
+        return result;
+
+    }
+    if (tokenizer2.MoveNext()) {
+      do {
+        number2 = tokenizer2.getNumber();
+        suffix2 = tokenizer2.getSuffix();
+        if (number2 != 0 || suffix2.length() != 0) {
+          // Version one is longer than version two, and non-zero
+          return -1;
+        }
+      } while (tokenizer2.MoveNext());
+
+      // Version two is longer than version one, but zero
+      return 0;
+    }
+    return 0;
+  }
+
+  // VersionTokenizer.java
+  class VersionTokenizer {
+    private final String _versionString;
+    private final int _length;
+
+    private int _position;
+    private int _number;
+    private String _suffix;
+    private boolean _hasValue;
+
+    public int getNumber() {
+      return _number;
+    }
+
+    public String getSuffix() {
+      return _suffix;
+    }
+
+    public boolean hasValue() {
+      return _hasValue;
+    }
+
+    public VersionTokenizer(String versionString) {
+      if (versionString == null)
+        throw new IllegalArgumentException("versionString is null");
+
+      _versionString = versionString;
+      _length = versionString.length();
+    }
+
+    public boolean MoveNext() {
+      _number = 0;
+      _suffix = "";
+      _hasValue = false;
+
+      // No more characters
+      if (_position >= _length)
+        return false;
+
+      _hasValue = true;
+
+      while (_position < _length) {
+        char c = _versionString.charAt(_position);
+        if (c < '0' || c > '9')
+          break;
+        _number = _number * 10 + (c - '0');
+        _position++;
+      }
+
+      int suffixStart = _position;
+
+      while (_position < _length) {
+        char c = _versionString.charAt(_position);
+        if (c == '.')
+          break;
+        _position++;
+      }
+
+      _suffix = _versionString.substring(suffixStart, _position);
+
+      if (_position < _length)
+        _position++;
+
+      return true;
     }
   }
 }

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -38,6 +38,9 @@ public class Msvc {
   @Parameter
   private String windowsSdkVersion;
 
+  @Parameter
+  private String tempPath;
+
   private File windowsHome;
   private String toolPathWindowsSDK;
   private String versionPathWindowsSDK = "";
@@ -107,7 +110,7 @@ public class Msvc {
       // cl needs TMP otherwise D8050 is raised c1xx.dll
       envVariable = new Variable();
       envVariable.setKey("TMP");
-      envVariable.setValue("C:\\Temp");
+      envVariable.setValue(getTempPath());
       task.addEnv(envVariable);
     }
   }
@@ -150,6 +153,17 @@ public class Msvc {
       linker.addLibraryDirectory(this.windowsSdkHome, "Lib" + versionPathWindowsSDK + "/ucrt/" + sdkArch); // 10+
       linker.addLibraryDirectory(this.windowsSdkHome, "Lib" + versionPathWindowsSDK + "/um/" + sdkArch); // 10+
     }
+  }
+
+  private String getTempPath(){
+    if( null == tempPath ){
+      tempPath = System.getenv("TMP");
+      if( null == tempPath )
+        tempPath = System.getenv("TEMP");
+      if( null == tempPath )
+        tempPath = "C:\\Temp";
+    }
+    return tempPath;
   }
 
   public Variable getPathVariable() {

--- a/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
+++ b/src/main/java/com/github/maven_nar/NarAssemblyMojo.java
@@ -56,7 +56,7 @@ public class NarAssemblyMojo extends AbstractDependencyMojo {
   @Override
   public final void narExecute() throws MojoExecutionException, MojoFailureException {
     // download the dependencies if needed in local maven repository.
-    List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(libraries);
     downloadAttachedNars(attachedNarArtifacts);
 
     // Warning, for SNAPSHOT artifacts that were not in the local maven
@@ -69,7 +69,7 @@ public class NarAssemblyMojo extends AbstractDependencyMojo {
     // -SNAPSHOT versions, so we call again getAttachedNarArtifacts() to get the
     // unmodified AttachedNarArtifact
     // objects
-    attachedNarArtifacts = getAttachedNarArtifacts();
+    attachedNarArtifacts = getAttachedNarArtifacts(libraries);
     unpackAttachedNars(attachedNarArtifacts);
 
     // this may make some extra copies...

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -222,7 +222,7 @@ public class NarCompileMojo extends AbstractCompileMojo {
     for (final Object element : dependencies) {
       // FIXME, handle multiple includes from one NAR
       final NarArtifact narDependency = (NarArtifact) element;
-      final String binding = narDependency.getNarInfo().getBinding(getAOL(), Library.STATIC);
+      final String binding = getBinding(library, narDependency);
       getLog().debug("Looking for " + narDependency + " found binding " + binding);
       if (!binding.equals(Library.JNI)) {
         final File unpackDirectory = getUnpackDirectory();

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -394,6 +394,14 @@ public class NarCompileMojo extends AbstractCompileMojo {
         }
       }
     }
+    if( getOS().equals(OS.WINDOWS) && Library.STATIC.equals(library.getType()) ){  // option? should debug symbols always be provided.
+      getLog().debug( "Copy static pdbs from intermediat dir to " + task.getOutfile().getParentFile() );
+      try {
+        NarUtil.copyDirectoryStructure(task.getObjdir(), task.getOutfile().getParentFile(), "**/*.pdb", NarUtil.DEFAULT_EXCLUDES );
+      } catch (IOException e) {
+        getLog().info( "Failed to copy pdbs from " + task.getObjdir() + "\nexception" + e.getMessage() );
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/github/maven_nar/NarDownloadDependenciesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarDownloadDependenciesMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 
@@ -39,6 +40,13 @@ import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 @Mojo(name = "nar-download-dependencies", defaultPhase = LifecyclePhase.GENERATE_SOURCES, requiresProject = true,
   requiresDependencyResolution = ResolutionScope.TEST)
 public class NarDownloadDependenciesMojo extends AbstractDependencyMojo {
+  
+  /**
+   * List of tests to create
+   */
+  @Parameter
+  private List tests;
+  
   /**
    * List all the dependencies of the project.
    */
@@ -50,7 +58,8 @@ public class NarDownloadDependenciesMojo extends AbstractDependencyMojo {
   @Override
   public void narExecute() throws MojoFailureException, MojoExecutionException {
     // download the dependencies if needed in local maven repository.
-    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(libraries);
+    attachedNarArtifacts.addAll( getAttachedNarArtifacts(tests) );
     downloadAttachedNars(attachedNarArtifacts);
   }
 

--- a/src/main/java/com/github/maven_nar/NarDownloadMojo.java
+++ b/src/main/java/com/github/maven_nar/NarDownloadMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 
@@ -44,6 +45,13 @@ import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 @Mojo(name = "nar-download", defaultPhase = LifecyclePhase.INITIALIZE, requiresProject = true,
   requiresDependencyResolution = ResolutionScope.TEST)
 public class NarDownloadMojo extends AbstractDependencyMojo {
+  
+  /**
+   * List of tests to create
+   */
+  @Parameter
+  private List tests;
+  
   /**
    * List all the dependencies which are needed by the project (for compilation,
    * tests, and execution).
@@ -55,7 +63,8 @@ public class NarDownloadMojo extends AbstractDependencyMojo {
 
   @Override
   public void narExecute() throws MojoFailureException, MojoExecutionException {
-    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(libraries);
+    attachedNarArtifacts.addAll( getAttachedNarArtifacts(tests) );
     downloadAttachedNars(attachedNarArtifacts);
   }
 }

--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -264,8 +264,7 @@ public class NarTestCompileMojo extends AbstractCompileMojo {
 
       // FIXME no handling of "local"
 
-      // FIXME, no way to override this at this stage
-      final String binding = dependency.getNarInfo().getBinding(getAOL(), Library.NONE);
+      final String binding = getBinding(test, dependency);
       getLog().debug("Using Binding: " + binding);
       AOL aol = getAOL();
       aol = dependency.getNarInfo().getAOL(getAOL());

--- a/src/main/java/com/github/maven_nar/NarTestUnpackMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestUnpackMojo.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 
@@ -42,6 +43,12 @@ import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 public class NarTestUnpackMojo extends AbstractDependencyMojo {
 
   /**
+   * List of tests to create
+   */
+  @Parameter
+  private List tests;
+  
+  /**
    * List the dependencies needed for tests compilations and executions.
    */
   @Override
@@ -56,7 +63,7 @@ public class NarTestUnpackMojo extends AbstractDependencyMojo {
 
   @Override
   public final void narExecute() throws MojoExecutionException, MojoFailureException {
-    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(tests);
     unpackAttachedNars(attachedNarArtifacts);
   }
 }

--- a/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
+++ b/src/main/java/com/github/maven_nar/NarUnpackDependenciesMojo.java
@@ -25,6 +25,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
@@ -40,6 +41,12 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
   requiresDependencyResolution = ResolutionScope.TEST, requiresProject = true)
 public class NarUnpackDependenciesMojo extends NarDownloadDependenciesMojo {
 
+  /**
+   * List of tests to create
+   */
+  @Parameter
+  private List tests;
+  
   @Override
   public void narExecute() throws MojoFailureException, MojoExecutionException {
     // download the dependencies if needed in local maven repository using
@@ -47,7 +54,7 @@ public class NarUnpackDependenciesMojo extends NarDownloadDependenciesMojo {
     super.narExecute();
 
     // unpack the nar files
-    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(tests);
     unpackAttachedNars(attachedNarArtifacts);
   }
 

--- a/src/main/java/com/github/maven_nar/NarUnpackMojo.java
+++ b/src/main/java/com/github/maven_nar/NarUnpackMojo.java
@@ -26,6 +26,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 
@@ -41,6 +42,12 @@ import org.apache.maven.shared.artifact.filter.collection.ScopeFilter;
 public class NarUnpackMojo extends AbstractDependencyMojo {
 
   /**
+   * List of tests to create
+   */
+  @Parameter
+  private List tests;
+  
+  /**
    * List the dependencies needed for compilation.
    */
   @Override
@@ -50,7 +57,7 @@ public class NarUnpackMojo extends AbstractDependencyMojo {
 
   @Override
   public final void narExecute() throws MojoExecutionException, MojoFailureException {
-    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts();
+    final List<AttachedNarArtifact> attachedNarArtifacts = getAttachedNarArtifacts(libraries);
     unpackAttachedNars(attachedNarArtifacts);
   }
 }

--- a/src/main/java/com/github/maven_nar/Test.java
+++ b/src/main/java/com/github/maven_nar/Test.java
@@ -67,9 +67,28 @@ public class Test implements Executable {
   @Parameter
   private List/* <String> */args = new ArrayList();
 
+  /**
+   * List of artifact:binding  for type of dependency to link against when there is a choice.
+   */
+  @Parameter
+  private List<String> dependencyBindings = new ArrayList<String>();
+  
+
   @Override
   public final List/* <String> */getArgs() {
     return this.args;
+  }
+
+  public String getBinding(NarArtifact dependency) {
+    for (String dependBind : dependencyBindings ) {
+      String[] pair = dependBind.trim().split( ":", 2 );  // TODO: match how much?
+      if( dependency.getArtifactId().equals(pair[0].trim()) ){
+        String result = pair[1].trim();
+        if( !result.isEmpty() )
+          return result;
+      }
+    }
+    return null;
   }
 
   public final String getLink( List<Library> libraries ) {
@@ -85,7 +104,7 @@ public class Test implements Executable {
     }
     return libraryPreferred == null ? Library.SHARED : libraryPreferred; 
   }
-
+  
   public final String getName() throws MojoFailureException {
     if (this.name == null) {
       throw new MojoFailureException("NAR: Please specify <Name> as part of <Test>");

--- a/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/TargetMatcher.java
@@ -89,8 +89,9 @@ public final class TargetMatcher implements FileVisitor {
     } else {
       //
       // get output file name
+      // requires full path as output name may be changed based on location
       //
-      final String[] outputFileNames = selectedCompiler.getOutputFileNames(filename, this.versionInfo);
+      final String[] outputFileNames = selectedCompiler.getOutputFileNames(fullPath.getPath(), this.versionInfo);
       this.sourceFiles[0] = fullPath;
       //
       // if there is some output for this task
@@ -100,14 +101,10 @@ public final class TargetMatcher implements FileVisitor {
         //
         // see if the same output file has already been registered
         //
-        StringBuffer sb = new StringBuffer(FilenameUtils.removeExtension(outputFileName));
-        sb.append("." + fullPath.getAbsolutePath().hashCode() + "." + FilenameUtils.getExtension(outputFileName) );
-        String newOutputFileName = sb.toString();
-
-        final TargetInfo previousTarget = this.targets.get(newOutputFileName);
+        final TargetInfo previousTarget = this.targets.get(outputFileName);
         if (previousTarget == null) {
-          this.targets.put(newOutputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
-              this.outputDir, newOutputFileName), selectedCompiler.getRebuild()));
+          this.targets.put(outputFileName, new TargetInfo(selectedCompiler, this.sourceFiles, null, new File(
+              this.outputDir, outputFileName), selectedCompiler.getRebuild()));
         } else {
           if (!previousTarget.getSources()[0].equals(this.sourceFiles[0])) {
             final StringBuffer builder = new StringBuffer("Output filename conflict: ");

--- a/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
@@ -125,6 +125,24 @@ public class BorlandCCompiler extends PrecompilingCommandLineCCompiler {
   }
 
   @Override
+  protected int getArgumentCountPerInputFile() {
+    return 3;
+  }
+
+  @Override
+  protected String getInputFileArgument(final File outputDir, final String filename, final int index) {
+    switch (index) {
+      case 0:
+        return "-o";
+      case 1:
+        final String outputFileName = getOutputFileNames(filename, null)[0];
+        final String objectName = new File(outputDir, outputFileName).toString();
+        return objectName;
+    }
+    return filename;
+  }
+
+  @Override
   protected void getDefineSwitch(final StringBuffer buffer, final String define, final String value) {
     BorlandProcessor.getDefineSwitch(buffer, define, value);
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.Vector;
 
+import org.apache.commons.io.FilenameUtils;
+
 import com.github.maven_nar.cpptasks.CCTask;
 import com.github.maven_nar.cpptasks.CUtil;
 import com.github.maven_nar.cpptasks.CompilerDef;
@@ -83,22 +85,9 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
   }
 
   abstract protected Parser createParser(File sourceFile);
-
+  
   protected String getBaseOutputName(final String inputFile) {
-    int lastSlash = inputFile.lastIndexOf('/');
-    final int lastReverse = inputFile.lastIndexOf('\\');
-    final int lastSep = inputFile.lastIndexOf(File.separatorChar);
-    if (lastReverse > lastSlash) {
-      lastSlash = lastReverse;
-    }
-    if (lastSep > lastSlash) {
-      lastSlash = lastSep;
-    }
-    int lastPeriod = inputFile.lastIndexOf('.');
-    if (lastPeriod < 0) {
-      lastPeriod = inputFile.length();
-    }
-    return inputFile.substring(lastSlash + 1, lastPeriod);
+    return FilenameUtils.getBaseName(inputFile);
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -193,10 +193,6 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
       }
 
       ArrayList<String> commandlinePrefix = new ArrayList<String>();
-      if (NarUtil.isWindows()) {
-        commandlinePrefix.add("cmd");
-        commandlinePrefix.add("/c");
-      }
       if (this.libtool) {
         commandlinePrefix.add("libtool");
       }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -141,6 +141,25 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     }
   }
 
+  @Override
+  public String[] getOutputFileNames(final String inputFile, final VersionInfo versionInfo) {
+    //
+    // if a recognized input file
+    //
+    if (bid(inputFile) > 1) {
+      final String baseName = getBaseOutputName(inputFile);
+      final File standardisedFile = new File(inputFile);
+      try {
+        return new String[] {
+          baseName + FilenameUtils.EXTENSION_SEPARATOR + Integer.toHexString(standardisedFile.getCanonicalPath().hashCode()) + getOutputSuffix()
+        };
+      } catch (IOException e) {
+        throw new BuildException("Source file not found", e);
+      }
+    }
+    return new String[0];
+  }
+
   /**
    * Compiles a source file.
    * 
@@ -205,16 +224,6 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
       for (int j = sourceIndex; j < firstFileNextExec; j++) {
         ArrayList<String> commandlineSuffix = new ArrayList<String>();
 
-        StringBuffer sb = new StringBuffer( FilenameUtils.getBaseName(sourceFiles[j]) );
-        sb.append( "." + sourceFiles[j].hashCode() + getOutputSuffix());
-        final String newOutputFileName = sb.toString();
-
-        if (NarUtil.isWindows()) {
-          commandlineSuffix.add("/Fo" + newOutputFileName);
-        } else {
-          commandlineSuffix.add("-o");
-          commandlineSuffix.add(newOutputFileName);
-        }
         for (int k = 0; k < argumentCountPerInputFile; k++) {
           commandlineSuffix.add(getInputFileArgument(outputDir, sourceFiles[j], k));
         }

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
@@ -139,6 +139,24 @@ public abstract class GccCompatibleCCompiler extends CommandLineCCompiler {
   }
 
   @Override
+  protected int getArgumentCountPerInputFile() {
+    return 3;
+  }
+
+  @Override
+  protected String getInputFileArgument(final File outputDir, final String filename, final int index) {
+    switch (index) {
+      case 0:
+        return "-o";
+      case 1:
+        final String outputFileName = getOutputFileNames(filename, null)[0];
+        final String objectName = new File(outputDir, outputFileName).toString();
+        return objectName;
+    }
+    return filename;
+  }
+
+  @Override
   public void getDefineSwitch(final StringBuffer buffer, final String define, final String value) {
     buffer.append("-D");
     buffer.append(define);

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
@@ -137,6 +137,21 @@ public abstract class MsvcCompatibleCCompiler extends PrecompilingCommandLineCCo
   }
 
   @Override
+  protected int getArgumentCountPerInputFile() {
+    return 2;
+  }
+
+  @Override
+  protected String getInputFileArgument(final File outputDir, final String filename, final int index) {
+    if (index == 0) {
+      final String outputFileName = getOutputFileNames(filename, null)[0];
+      final String fullOutputName = new File(outputDir, outputFileName).toString();
+      return "/Fo" + fullOutputName;
+    }
+    return filename;
+  }
+
+  @Override
   protected void getDefineSwitch(final StringBuffer buffer, final String define, final String value) {
     MsvcProcessor.getDefineSwitch(buffer, define, value);
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
@@ -113,6 +113,20 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
   }
 
   @Override
+  public String[] getOutputFileNames(final String inputFile, final VersionInfo versionInfo) {
+    //
+    // if a recognized input file
+    //
+    if (bid(inputFile) > 1) {
+      final String baseName = getBaseOutputName(inputFile);
+      return new String[] {
+        baseName + getOutputSuffix()
+      };
+    }
+    return new String[0];
+  }
+  
+  @Override
   protected String getInputFileArgument(final File outputDir, final String filename, final int index) {
     switch (index) {
       case 0:

--- a/src/test/java/com/github/maven_nar/cpptasks/compiler/TestCompilerConfiguration.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/compiler/TestCompilerConfiguration.java
@@ -64,15 +64,20 @@ public abstract class TestCompilerConfiguration extends TestCase {
 
   public void testGetOutputFileName2() {
     final CompilerConfiguration compiler = create();
-    String[] output = compiler.getOutputFileNames("c:/foo\\bar\\hello.c", null);
-    assertEquals("hello" + getObjectFileExtension(), output[0]);
-    output = compiler.getOutputFileNames("c:/foo\\bar/hello.c", null);
-    assertEquals("hello" + getObjectFileExtension(), output[0]);
+//    String[] output = compiler.getOutputFileNames("c:\\foo\\bar\\hello.c", null);  Windows only, on *nix gets treated as filename not pathed.
+    String[] output = compiler.getOutputFileNames("c:/foo/bar/hello.c", null);
+    String[] output2 = compiler.getOutputFileNames("c:/foo/bar/fake/../hello.c", null);
+    assertEquals(output[0], output2[0]); // files in same location get mangled same way - full path
+
     output = compiler.getOutputFileNames("hello.c", null);
-    assertEquals("hello" + getObjectFileExtension(), output[0]);
-    output = compiler.getOutputFileNames("c:/foo\\bar\\hello.h", null);
+    assertNotSame(output[0], output2[0]); // files in different folders get mangled in different way
+    
+    output2 = compiler.getOutputFileNames("fake/../hello.c", null);
+    assertEquals(output[0], output2[0]); // files in same location get mangled same way - relative path
+    
+    output = compiler.getOutputFileNames("c:/foo/bar/hello.h", null);
     assertEquals(0, output.length);
-    output = compiler.getOutputFileNames("c:/foo\\bar/hello.h", null);
+    output = compiler.getOutputFileNames("c:/foo/bar/fake/../hello.h", null);
     assertEquals(0, output.length);
   }
 }


### PR DESCRIPTION
Again removing usage of cmd.exe on windows
Re factoring of the Conflicting output names, original was causing windows resource and idl compiles to fail.

Include MSVC symbols for static builds into the build artifact
Support for Windows Platform SDK 10 with multiple installed versions 'evergreen'