### PR TITLE
Native lib loader searching also the "shared" directory and not only "jni"

### DIFF
--- a/src/main/java/com/github/maven_nar/NarSystemMojo.java
+++ b/src/main/java/com/github/maven_nar/NarSystemMojo.java
@@ -102,6 +102,9 @@ public class NarSystemMojo extends AbstractNarMojo {
     builder
         .append("            final File file = new File(prefix + aol + \"-jni/lib/\" + aol + \"/jni/\" + mapped);\n");
     builder.append("            if (file.isFile()) return file;\n");
+    builder
+    	.append("            final File file_shared = new File(prefix + aol + \"-jni/lib/\" + aol + \"/shared/\" + mapped);\n");
+    builder.append("            if (file_shared.isFile()) return file_shared;\n");    
     builder.append("        }\n");
     builder.append("        return null;\n");
     builder.append("    }\n");
@@ -111,6 +114,8 @@ public class NarSystemMojo extends AbstractNarMojo {
     builder.append("        for (final String aol : aols) {\n");
     builder.append("            final String libPath = \"lib/\" + aol + \"/jni/\";\n");
     builder.append("            if (loader.getResource(libPath + mapped) != null) return libPath;\n");
+    builder.append("            final String libPath_shared = \"lib/\" + aol + \"/shared/\";\n");
+    builder.append("            if (loader.getResource(libPath_shared + mapped) != null) return libPath_shared;\n");
     builder.append("        }\n");
     builder.append("        throw new RuntimeException(\"Library '\" + mapped + \"' not found!\");\n");
     builder.append("    }\n");


### PR DESCRIPTION
Hi!

I have a project setup with 3 projects where I use JNI to access a shared library using native lib loader.
However, the nativelibloader does not find the shared library as it only searches the JNI folder but not the shared folder thus resulting in an error that the library could not be loaded because the dependency was not found.

For me, this small change solves the problem.

Best
Thomas