### PR TITLE
Skipping make step in gnu process

### DIFF
--- a/src/main/java/com/github/maven_nar/NarGnuMakeMojo.java
+++ b/src/main/java/com/github/maven_nar/NarGnuMakeMojo.java
@@ -45,6 +45,13 @@ public class NarGnuMakeMojo extends AbstractGnuMojo {
    */
   @Parameter(defaultValue = "")
   private String gnuMakeEnv;
+  
+  /**
+   * Skip running of make.
+   * Useful if you just want to run the configure step for generating source.
+   */
+  @Parameter(property = "nar.gnu.make.skip")
+  private boolean gnuMakeSkip;
 
   /**
    * Boolean to control if we should skip 'make install' after the make
@@ -54,7 +61,7 @@ public class NarGnuMakeMojo extends AbstractGnuMojo {
 
   @Override
   public final void narExecute() throws MojoExecutionException, MojoFailureException {
-    if (!useGnu()) {
+    if (!useGnu() || gnuMakeSkip) {
       return;
     }
 

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -55,6 +55,7 @@ NAR Configuration
   <gnuTargetDirectory/>
   <gnuAutogenSkip/>
   <gnuConfigureSkip/>
+  <gnuMakeSkip/>
 
   <libraries>
     <library>
@@ -260,6 +261,11 @@ Default is dynamic.
 
 	Set use of libtool. If set to true, the "libtool " will be prepended to 
 the command line for compatible compilers/linkers. Default is false.
+
+* {gnuMakeSkip}
+    
+    Skip the GNU Make step if you are using the GNU stages. This is useful if you 
+wish to run a GNU configure step but not the full make process.
 
 * {libraries}
 


### PR DESCRIPTION
Enables you to skip the GNU Make step if you are using the GNU stages. This is useful if you wish to run a GNU configure step but not the full make process, for example, if you are generating define headers in the configure stage.