### PR TITLE
Switch from BCEL 5.2 to BCEL 6 to support Java 8 classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,9 +150,9 @@
       <version>1.8.1</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.bcel</groupId>
-      <artifactId>bcel</artifactId>
-      <version>5.2</version>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>bcel-findbugs</artifactId>
+      <version>6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Bug [BCEL-173](https://issues.apache.org/jira/browse/BCEL-173) causes
the nar-javah step to fail when used on classes using the
`invokedynamic` statement. Switching to BCEL 6 solves this problem.