### PR TITLE
Prefix for gcc g++ based compiler

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -63,6 +63,12 @@ public abstract class Compiler {
   private String name;
 
   /**
+   * The prefix for the compiler.
+   */
+  @Parameter
+  private String prefix;
+
+  /**
    * Path location of the compile tool
    */
   @Parameter
@@ -281,6 +287,7 @@ public abstract class Compiler {
     }
 
     // debug, exceptions, rtti, multiThreaded
+    compilerDef.setCompilerPrefix(this.prefix);
     compilerDef.setCcache(this.ccache);
     compilerDef.setDebug(this.debug);
     compilerDef.setExceptions(this.exceptions);
@@ -535,6 +542,9 @@ public abstract class Compiler {
     // adjust default values
     if (this.name == null) {
       this.name = NarProperties.getInstance(this.mojo.getMavenProject()).getProperty(getPrefix() + "compiler");
+    }
+    if (this.prefix == null) {
+      this.prefix = NarProperties.getInstance(this.mojo.getMavenProject()).getProperty(getPrefix() + "prefix");
     }
     return this.name;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -1300,25 +1300,27 @@ public class CCTask extends Task {
     //
     // add fallback compiler at the end
     //
-    final ProcessorConfiguration config = this.compilerDef.createConfiguration(this, this.linkType, null,
-        targetPlatform, versionInfo);
-    biddingProcessors.addElement(config);
-    final ProcessorConfiguration[] bidders = new ProcessorConfiguration[biddingProcessors.size()];
-    biddingProcessors.copyInto(bidders);
-    //
-    // bid out the <fileset>'s in the cctask
-    //
-    final TargetMatcher matcher = new TargetMatcher(this, this._objDir, bidders, linkerConfig, objectFiles, targets,
-        versionInfo);
-    this.compilerDef.visitFiles(matcher);
+    if (this._compilers.size()==0) {
+      final ProcessorConfiguration config = this.compilerDef.createConfiguration(this, this.linkType, null,
+          targetPlatform, versionInfo);
+      biddingProcessors.addElement(config);
+      final ProcessorConfiguration[] bidders = new ProcessorConfiguration[biddingProcessors.size()];
+      biddingProcessors.copyInto(bidders);
+      //
+      // bid out the <fileset>'s in the cctask
+      //
+      final TargetMatcher matcher = new TargetMatcher(this, this._objDir, bidders, linkerConfig, objectFiles, targets,
+          versionInfo);
+      this.compilerDef.visitFiles(matcher);
 
-    if (outputFile != null && versionInfo != null) {
-      final boolean isDebug = linkerConfig.isDebug();
-      try {
-        linkerConfig.getLinker()
-            .addVersionFiles(versionInfo, this.linkType, outputFile, isDebug, this._objDir, matcher);
-      } catch (final IOException ex) {
-        throw new BuildException(ex);
+      if (outputFile != null && versionInfo != null) {
+        final boolean isDebug = linkerConfig.isDebug();
+        try {
+          linkerConfig.getLinker()
+              .addVersionFiles(versionInfo, this.linkType, outputFile, isDebug, this._objDir, matcher);
+        } catch (final IOException ex) {
+          throw new BuildException(ex);
+        }
       }
     }
     return targets;

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -58,6 +58,7 @@ public final class CompilerDef extends ProcessorDef {
   private int warnings = -1;
   private List<String> order;
   private String toolPath;
+  private String compilerPrefix;
 
   private boolean clearDefaultOptions;
 
@@ -320,6 +321,10 @@ public final class CompilerDef extends ProcessorDef {
     return this.toolPath;
   }
 
+  public String getCompilerPrefix() {
+    return this.compilerPrefix;
+  }
+
   public int getWarnings(final CompilerDef[] defaultProviders, final int index) {
     if (isReference()) {
       return ((CompilerDef) getCheckedRef(CompilerDef.class, "CompilerDef")).getWarnings(defaultProviders, index);
@@ -552,6 +557,10 @@ public final class CompilerDef extends ProcessorDef {
 
   public void setToolPath(final String path) {
     this.toolPath = path;
+  }
+
+  public void setCompilerPrefix(final String prefix) {
+    this.compilerPrefix = prefix;
   }
 
   /**

--- a/src/main/java/com/github/maven_nar/cpptasks/LinkerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/LinkerDef.java
@@ -59,6 +59,7 @@ public class LinkerDef extends ProcessorDef {
   private int stack;
   private final Vector sysLibrarySets = new Vector();
   private String toolPath;
+  private String linkerPrefix;
 
   private final Set<File> libraryDirectories = new LinkedHashSet<File>();
 
@@ -322,6 +323,10 @@ public class LinkerDef extends ProcessorDef {
     return this.toolPath;
   }
 
+  public String getLinkerPrefix() {
+    return this.linkerPrefix;
+  }
+
   /**
    * Sets the base address. May be specified in either decimal or hex.
    * 
@@ -501,6 +506,10 @@ public class LinkerDef extends ProcessorDef {
 
   public void setToolPath(final String path) {
     this.toolPath = path;
+  }
+
+  public void setLinkerPrefix(final String prefix) {
+    this.linkerPrefix = prefix;
   }
 
   public void visitSystemLibraries(final Linker linker, final FileVisitor libraryVisitor) {

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -53,6 +53,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
   /** Command used when invoking ccache */
   private static final String CCACHE_CMD = "ccache";
   private String command;
+  private String prefix;
   private final Environment env;
   private String identifier;
   private final String identifierArg;
@@ -62,7 +63,6 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
 
   protected CommandLineCompiler(final String command, final String identifierArg, final String[] sourceExtensions,
       final String[] headerExtensions,
-
       final String outputSuffix, final boolean libtool, final CommandLineCompiler libtoolCompiler,
       final boolean newEnvironment, final Environment env) {
     super(sourceExtensions, headerExtensions, outputSuffix);
@@ -276,6 +276,9 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
   protected CompilerConfiguration createConfiguration(final CCTask task, final LinkType linkType,
       final ProcessorDef[] baseDefs, final CompilerDef specificDef, final TargetDef targetPlatform,
       final VersionInfo versionInfo) {
+
+    this.prefix = specificDef.getCompilerPrefix();
+
     final Vector<String> args = new Vector<String>();
     final CompilerDef[] defaultProviders = new CompilerDef[baseDefs.length + 1];
     for (int i = 0; i < baseDefs.length; i++) {
@@ -283,6 +286,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     }
     defaultProviders[0] = specificDef;
     final Vector<CommandLineArgument> cmdArgs = new Vector<CommandLineArgument>();
+
     //
     // add command line arguments inherited from <cc> element
     // any "extends" and finally the specific CompilerDef
@@ -428,7 +432,11 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
   }
 
   protected final String getCommand() {
-    return this.command;
+    if (this.prefix != null && (!this.prefix.isEmpty())) {
+      return this.prefix + this.command;
+    } else {
+      return this.command;
+    }
   }
 
   public String getCommandWithPath(final CommandLineCompilerConfiguration config) {
@@ -454,12 +462,12 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     if (this.identifier == null) {
       if (this.identifierArg == null) {
         this.identifier = getIdentifier(new String[] {
-          this.command
-        }, this.command);
+          this.getCommand()
+        }, this.getCommand());
       } else {
         this.identifier = getIdentifier(new String[] {
-            this.command, this.identifierArg
-        }, this.command);
+          this.getCommand(), this.identifierArg
+        }, this.getCommand());
       }
     }
     return this.identifier;

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineLinker.java
@@ -50,6 +50,7 @@ import com.github.maven_nar.cpptasks.types.LibrarySet;
  */
 public abstract class CommandLineLinker extends AbstractLinker {
   private String command;
+  private String prefix;
   private Environment env = null;
   private String identifier;
   private final String identifierArg;
@@ -142,11 +143,14 @@ public abstract class CommandLineLinker extends AbstractLinker {
         preargs, midargs, endargs
     };
 
+    this.prefix  = specificDef.getLinkerPrefix();
+
     final LinkerDef[] defaultProviders = new LinkerDef[baseDefs.length + 1];
     defaultProviders[0] = specificDef;
     for (int i = 0; i < baseDefs.length; i++) {
       defaultProviders[i + 1] = (LinkerDef) baseDefs[i];
     }
+
     //
     // add command line arguments inherited from <cc> element
     // any "extends" and finally the specific CompilerDef
@@ -258,7 +262,11 @@ public abstract class CommandLineLinker extends AbstractLinker {
   }
 
   protected final String getCommand() {
-    return this.command;
+    if (this.prefix != null && (!this.prefix.isEmpty())) {
+      return this.prefix + this.command;
+    } else {
+      return this.command;
+    }
   }
 
   protected abstract String getCommandFileSwitch(String commandFile);
@@ -282,12 +290,12 @@ public abstract class CommandLineLinker extends AbstractLinker {
     if (this.identifier == null) {
       if (this.identifierArg == null) {
         this.identifier = getIdentifier(new String[] {
-          this.command
-        }, this.command);
+          this.getCommand()
+        }, this.getCommand());
       } else {
         this.identifier = getIdentifier(new String[] {
-            this.command, this.identifierArg
-        }, this.command);
+          this.getCommand(), this.identifierArg
+        }, this.getCommand());
       }
     }
     return this.identifier;

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -84,6 +84,7 @@ NAR Configuration
 
   <linker>
     <name/>
+    <prefix/>
     <toolPath/>
     <incremental/>
     <map/>
@@ -111,6 +112,7 @@ NAR Configuration
 
   <cpp>
     <name/>
+    <prefix/>
     <toolPath/>
     <sourceDirectory/>
     <includes>
@@ -321,6 +323,10 @@ wish to run a GNU configure step but not the full make process.
 	The Linker. Some choices are: "msvc", "g++", "CC", "icpc", ...
     Default is Architecture OS specific.
 
+** {linker prefix}
+
+    Add prefix to the linker name: "prefix-name"
+
 ** {linker toolPath}
 
 	The path that the linker is located within.  Default is to use the system's environment.
@@ -378,6 +384,10 @@ wish to run a GNU configure step but not the full make process.
 	The name of the compiler. Some choices are: "msvc", "g++", "gcc", "CC", "cc", "icc", "icpc", ...
     Default is AOL specific.
     
+** {cpp prefix}
+
+    Add prefix to the compiler name: "prefix-name"
+
 ** {cpp toolPath}
 
 	The path that the compiler is located within.  Default is to use the system's environment.


### PR DESCRIPTION
This change add:

 - new tag ```<prefix>``` into ```<linker>```, ```<cpp>```, ```<c>```, ```<fortran>``` section.
Now we can compile and link with a cross-compiler or a custom compiler.

 - change behavior for the fallback compiler in CCTask, if there is no compiler define then use the fallback one. I wonder if this change should not be into another commit, but the feature is dependent on this modification.

Signed-off-by: Grégory Wilga <gwilga@gmail.com>