### PR TITLE
Add more path to look for installed windows SDK.

### DIFF
--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -338,8 +338,11 @@ public class Msvc {
     String maxVersion = "";
     File home = null;
     mojo.getLog().debug(" -- Searching for usable WindowSDK ");
-    for (final File directory : Arrays.asList(new File("C:/Program Files (x86)/Microsoft SDKs/Windows"), new File(
-        "C:/Program Files (x86)/Windows Kits"))) {
+    for (final File directory : Arrays.asList(
+            new File("C:/Program Files (x86)/Microsoft SDKs/Windows"),
+            new File("C:/Program Files (x86)/Windows Kits"),
+            new File("C:/Program Files/Microsoft SDKs/Windows"),
+            new File("C:/Program Files/Windows Kits") )) {
       if (directory.exists()) {
         final File[] kitDirectories = directory.listFiles();
         if (kitDirectories != null) {


### PR DESCRIPTION
Regarding official documentation for windows SDK, installation can be into "C:\Program Files".
https://msdn.microsoft.com/en-us/library/ms717422%28v=vs.110%29.aspx
https://msdn.microsoft.com/en-us/library/ms717422%28v=vs.100%29.aspx

We should be able to check this directory too.

Signed-off-by: Grégory Wilga <gwilga@gmail.com>