### PR TITLE
Change the algorithm to select the Windows SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.github.maven-nar</groupId>
   <artifactId>nar-maven-plugin</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Native ARchive plugin for Maven</name>


### PR DESCRIPTION
In my current windows SDK installation, I only have windows 10 ucrt folder. I needed to change the algorithm to be able to compile with this SDK.

Will now search for the correct library paths, by combining the windows 10 SDK's with the previous
SDK's. This is done by selecting Windows 10 SDK's above the older ones; i.e. search first in Windows 10 library (newest first) and the next libs will be 8.1, 8.0, 7.1. This should make the algorithm more general.