### PR TITLE
Change compiler working directory

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -464,7 +464,16 @@ public abstract class Compiler {
         compilerDef.addFileset(fileSet);
       }
     }
-
+    
+    if (type.equals(TEST)) {
+      if (this.testSourceDirectory.exists()) {
+        compilerDef.setWorkDir(this.testSourceDirectory);
+      }
+    } else {
+      if (this.sourceDirectory.exists()) {
+        compilerDef.setWorkDir(this.sourceDirectory);
+      }
+    }
     return compilerDef;
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -46,6 +46,8 @@ import com.github.maven_nar.cpptasks.compiler.Linker;
 import com.github.maven_nar.cpptasks.compiler.LinkerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.Processor;
 import com.github.maven_nar.cpptasks.compiler.ProcessorConfiguration;
+import com.github.maven_nar.cpptasks.compiler.AbstractCompiler;
+import com.github.maven_nar.cpptasks.compiler.CommandLineCompilerConfiguration;
 import com.github.maven_nar.cpptasks.ide.ProjectDef;
 import com.github.maven_nar.cpptasks.types.CompilerArgument;
 import com.github.maven_nar.cpptasks.types.ConditionalFileSet;
@@ -1240,6 +1242,9 @@ public class CCTask extends Task {
         // see if this processor had a precompile child element
         //
         final PrecompileDef precompileDef = currentCompilerDef.getActivePrecompile(this.compilerDef);
+        CommandLineCompilerConfiguration commandLineConfig = (CommandLineCompilerConfiguration) config;
+        AbstractCompiler compiler = (AbstractCompiler) commandLineConfig.getCompiler();
+        compiler.setWorkDir(currentCompilerDef.getWorkDir());
         ProcessorConfiguration[] localConfigs = new ProcessorConfiguration[] {
           config
         };

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -36,6 +36,7 @@ import com.github.maven_nar.cpptasks.types.DefineSet;
 import com.github.maven_nar.cpptasks.types.IncludePath;
 import com.github.maven_nar.cpptasks.types.SystemIncludePath;
 import com.github.maven_nar.cpptasks.types.UndefineArgument;
+import java.io.File;
 
 /**
  * A compiler definition. compiler elements may be placed either as children of
@@ -59,6 +60,7 @@ public final class CompilerDef extends ProcessorDef {
   private List<String> order;
   private String toolPath;
   private String compilerPrefix;
+  private File workDir;
 
   private boolean clearDefaultOptions;
 
@@ -325,6 +327,10 @@ public final class CompilerDef extends ProcessorDef {
     return this.compilerPrefix;
   }
 
+  public File getWorkDir() {
+      return this.workDir;
+  }
+  
   public int getWarnings(final CompilerDef[] defaultProviders, final int index) {
     if (isReference()) {
       return ((CompilerDef) getCheckedRef(CompilerDef.class, "CompilerDef")).getWarnings(defaultProviders, index);
@@ -563,6 +569,10 @@ public final class CompilerDef extends ProcessorDef {
     this.compilerPrefix = prefix;
   }
 
+  public void setWorkDir(final File workDir) {
+      this.workDir = workDir;
+  }
+  
   /**
    * Enumerated attribute with the values "none", "severe", "default",
    * "production", "diagnostic", and "aserror".

--- a/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
@@ -31,6 +31,7 @@ import com.github.maven_nar.cpptasks.compiler.LinkType;
 import com.github.maven_nar.cpptasks.compiler.Linker;
 import com.github.maven_nar.cpptasks.compiler.PrecompilingCommandLineCCompiler;
 import com.github.maven_nar.cpptasks.compiler.Processor;
+import org.apache.tools.ant.util.FileUtils;
 
 /**
  * Adapter for the Borland(r) C/C++ compiler.
@@ -139,7 +140,16 @@ public class BorlandCCompiler extends PrecompilingCommandLineCCompiler {
         final String objectName = new File(outputDir, outputFileName).toString();
         return objectName;
     }
-    return filename;
+    String relative="";
+    try {
+      relative = FileUtils.getRelativePath(workDir, new File(filename));
+    } catch (Exception ex) {
+    }
+    if (relative.isEmpty()) {
+      return filename;
+    } else {
+      return relative;
+    }
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
@@ -46,6 +46,8 @@ import com.github.maven_nar.cpptasks.parser.Parser;
 public abstract class AbstractCompiler extends AbstractProcessor implements Compiler {
   private static final String[] emptyIncludeArray = new String[0];
   private final String outputSuffix;
+  protected File workDir;
+  protected File objDir;
 
   protected AbstractCompiler(final String[] sourceExtensions, final String[] headerExtensions, final String outputSuffix) {
     super(sourceExtensions, headerExtensions);
@@ -200,5 +202,13 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
 
   public final String getOutputSuffix() {
     return this.outputSuffix;
+  }
+
+  public void setWorkDir(final File workDir) {
+    this.workDir = workDir;
+  }
+
+  public void setObjDir(final File objDir) {
+    this.objDir = objDir;
   }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -42,6 +42,7 @@ import com.github.maven_nar.cpptasks.types.CommandLineArgument;
 import com.github.maven_nar.cpptasks.types.UndefineArgument;
 import com.github.maven_nar.cpptasks.compiler.CommandLineCCompiler;
 import com.google.common.collect.ObjectArrays;
+import org.apache.tools.ant.util.FileUtils;
 
 /**
  * An abstract Compiler implementation which uses an external program to
@@ -233,7 +234,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
 
         ArrayList<String> commandline = new ArrayList<String>(commandlinePrefix);
         commandline.addAll(commandlineSuffix);
-        final int ret = runCommand(task, outputDir,
+        final int ret = runCommand(task, workDir,
             commandline.toArray(new String[commandline.size()]));
         if (ret != 0) { retval = ret; }
       }
@@ -278,7 +279,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
       final VersionInfo versionInfo) {
 
     this.prefix = specificDef.getCompilerPrefix();
-
+    this.objDir = task.getObjdir();
     final Vector<String> args = new Vector<String>();
     final CompilerDef[] defaultProviders = new CompilerDef[baseDefs.length + 1];
     for (int i = 0; i < baseDefs.length; i++) {
@@ -495,13 +496,24 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     //
     // if there is an embedded space,
     // must enclose in quotes
-    if (filename.indexOf(' ') >= 0) {
+    String relative="";
+    String inputFile;
+    try {
+      relative = FileUtils.getRelativePath(workDir, new File(filename));
+    } catch (Exception ex) {
+    }
+    if (relative.isEmpty()) {
+      inputFile = filename;
+    } else {
+      inputFile = relative;
+    }
+    if (inputFile.indexOf(' ') >= 0) {
       final StringBuffer buf = new StringBuffer("\"");
-      buf.append(filename);
+      buf.append(inputFile);
       buf.append("\"");
       return buf.toString();
     }
-    return filename;
+    return inputFile;
   }
 
   protected final boolean getLibtool() {

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
@@ -28,6 +28,7 @@ import com.github.maven_nar.cpptasks.CUtil;
 import com.github.maven_nar.cpptasks.OptimizationEnum;
 import com.github.maven_nar.cpptasks.compiler.CommandLineCCompiler;
 import com.github.maven_nar.cpptasks.compiler.LinkType;
+import org.apache.tools.ant.util.FileUtils;
 
 /**
  * Abstract base class for compilers that attempt to be command line compatible
@@ -153,7 +154,16 @@ public abstract class GccCompatibleCCompiler extends CommandLineCCompiler {
         final String objectName = new File(outputDir, outputFileName).toString();
         return objectName;
     }
-    return filename;
+    String relative="";
+      try {
+          relative = FileUtils.getRelativePath(workDir, new File(filename));
+      } catch (Exception ex) {
+      }
+      if (relative.isEmpty()) {
+          return filename;
+      } else {
+          return relative;
+      }
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/Msvc2005CCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/Msvc2005CCompiler.java
@@ -19,6 +19,7 @@
  */
 package com.github.maven_nar.cpptasks.msvc;
 
+import java.io.File;
 import java.util.Vector;
 
 import org.apache.tools.ant.types.Environment;
@@ -49,6 +50,7 @@ public final class Msvc2005CCompiler extends MsvcCompatibleCCompiler {
   @Override
   protected void addDebugSwitch(final Vector<String> args) {
     args.addElement("/Zi");
+    args.addElement("/Fd" + objDir.getAbsolutePath() + File.separator);
     args.addElement("/Od");
     args.addElement("/RTC1");
     args.addElement("/D_DEBUG");

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
@@ -31,6 +31,7 @@ import com.github.maven_nar.cpptasks.compiler.CommandLineCompilerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.CompilerConfiguration;
 import com.github.maven_nar.cpptasks.compiler.LinkType;
 import com.github.maven_nar.cpptasks.compiler.PrecompilingCommandLineCCompiler;
+import org.apache.tools.ant.util.FileUtils;
 
 /**
  * An abstract base class for compilers that are basically command line
@@ -59,6 +60,7 @@ public abstract class MsvcCompatibleCCompiler extends PrecompilingCommandLineCCo
 
   protected void addDebugSwitch(final Vector<String> args) {
     args.addElement("/Zi");
+    args.addElement("/Fd" + objDir.getAbsolutePath() + File.separator);
     args.addElement("/Od");
     args.addElement("/RTC1");
     args.addElement("/D_DEBUG");
@@ -148,7 +150,17 @@ public abstract class MsvcCompatibleCCompiler extends PrecompilingCommandLineCCo
       final String fullOutputName = new File(outputDir, outputFileName).toString();
       return "/Fo" + fullOutputName;
     }
-    return filename;
+
+    String relative="";
+      try {
+        relative = FileUtils.getRelativePath(workDir, new File(filename));
+      } catch (Exception ex) {
+      }
+      if (relative.isEmpty()) {
+          return filename;
+      } else {
+          return relative;
+      }
   }
 
   @Override

--- a/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvc2005CCompiler.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvc2005CCompiler.java
@@ -19,6 +19,7 @@
  */
 package com.github.maven_nar.cpptasks.msvc;
 
+import java.io.File;
 import java.util.Vector;
 
 import junit.framework.TestCase;
@@ -35,11 +36,14 @@ public class TestMsvc2005CCompiler extends TestCase {
   public void testDebug() {
     final Msvc2005CCompiler compiler = Msvc2005CCompiler.getInstance();
     final Vector args = new Vector();
+    final File objDir = new File("dummy");
+    compiler.setObjDir(objDir);
     compiler.addDebugSwitch(args);
-    assertEquals(4, args.size());
+    assertEquals(5, args.size());
     assertEquals("/Zi", args.elementAt(0));
-    assertEquals("/Od", args.elementAt(1));
-    assertEquals("/RTC1", args.elementAt(2));
-    assertEquals("/D_DEBUG", args.elementAt(3));
+    assertEquals("/Fd" + objDir.getAbsolutePath() + File.separator, args.elementAt(1));
+    assertEquals("/Od", args.elementAt(2));
+    assertEquals("/RTC1", args.elementAt(3));
+    assertEquals("/D_DEBUG", args.elementAt(4));
   }
 }

--- a/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvcCCompiler.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvcCCompiler.java
@@ -19,6 +19,7 @@
  */
 package com.github.maven_nar.cpptasks.msvc;
 
+import java.io.File;
 import java.util.Vector;
 
 import junit.framework.TestCase;
@@ -35,11 +36,14 @@ public class TestMsvcCCompiler extends TestCase {
   public void testDebug() {
     final MsvcCCompiler compiler = MsvcCCompiler.getInstance();
     final Vector args = new Vector();
+    final File objDir = new File("dummy");
+    compiler.setObjDir(objDir);
     compiler.addDebugSwitch(args);
-    assertEquals(4, args.size());
+    assertEquals(5, args.size());
     assertEquals("/Zi", args.elementAt(0));
-    assertEquals("/Od", args.elementAt(1));
-    assertEquals("/RTC1", args.elementAt(2));
-    assertEquals("/D_DEBUG", args.elementAt(3));
+    assertEquals("/Fd" + objDir.getAbsolutePath() + File.separator, args.elementAt(1));
+    assertEquals("/Od", args.elementAt(2));
+    assertEquals("/RTC1", args.elementAt(3));
+    assertEquals("/D_DEBUG", args.elementAt(4));
   }
 }


### PR DESCRIPTION
At current moment compiler command is executing in object directory,
where results of compilation (object files) are placed
(e.g. ${project.build.directory}/target/nar/obj/amd64-Linux-gpp).

It is more logical to use sourceDirectory as compiler working directory.
This allows cut path to source files and makes compiler command some shorter.

This PR can resolve #158 issue.