### PR TITLE
Fix JNI library extensions on OSX

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -630,16 +630,16 @@ ppc.MacOSX.gpp.shared.prefix=lib
 ppc.MacOSX.gpp.static.extension=a
 ppc.MacOSX.gpp.shared.extension=dylib
 ppc.MacOSX.gpp.plugin.extension=bundle
-ppc.MacOSX.gpp.jni.extension=jnilib
+ppc.MacOSX.gpp.jni.extension=dylib
 ppc.MacOSX.gpp.executable.extension=
 
 # FIXME to be removed when NAR-6
 ppc.MacOSX.gcc.static.extension=a
 ppc.MacOSX.gcc.shared.extension=dylib
 ppc.MacOSX.gcc.plugin.extension=bundle
-ppc.MacOSX.gcc.jni.extension=jnilib
+ppc.MacOSX.gcc.jni.extension=dylib
 
-#ppc.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib lib/**/*.jnilib
+#ppc.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib
 
 #
 # MacOSX ("Mac OS X" => MacOSX) Intel (32 bits)
@@ -672,16 +672,16 @@ i386.MacOSX.gpp.shared.prefix=lib
 i386.MacOSX.gpp.static.extension=a
 i386.MacOSX.gpp.shared.extension=dylib
 i386.MacOSX.gpp.plugin.extension=bundle
-i386.MacOSX.gpp.jni.extension=jnilib
+i386.MacOSX.gpp.jni.extension=dylib
 i386.MacOSX.gpp.executable.extension=
 
 # FIXME to be removed when NAR-6
 i386.MacOSX.gcc.static.extension=a
 i386.MacOSX.gcc.shared.extension=dylib
 i386.MacOSX.gcc.plugin.extension=bundle
-i386.MacOSX.gcc.jni.extension=jnilib
+i386.MacOSX.gcc.jni.extension=dylib
 
-#i386.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib lib/**/*.jnilib
+#i386.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib
 
 #
 # MacOSX ("Mac OS X" => MacOSX) Intel (64 bits)
@@ -714,16 +714,16 @@ x86_64.MacOSX.gpp.shared.prefix=lib
 x86_64.MacOSX.gpp.static.extension=a
 x86_64.MacOSX.gpp.shared.extension=dylib
 x86_64.MacOSX.gpp.plugin.extension=bundle
-x86_64.MacOSX.gpp.jni.extension=jnilib
+x86_64.MacOSX.gpp.jni.extension=dylib
 x86_64.MacOSX.gpp.executable.extension=
 
 # FIXME to be removed when NAR-6
 x86_64.MacOSX.gcc.static.extension=a
 x86_64.MacOSX.gcc.shared.extension=dylib
 x86_64.MacOSX.gcc.plugin.extension=bundle
-x86_64.MacOSX.gcc.jni.extension=jnilib
+x86_64.MacOSX.gcc.jni.extension=dylib
 
-x86_64.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib lib/**/*.jnilib
+x86_64.MacOSX.gpp.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib
 
 # Here is the AOL for x86_64-MacOSX-icpc, pretty simple without any default compiler options, works for me ... if i make further changes or add new stuff i will let you know ...
 
@@ -756,16 +756,16 @@ x86_64.MacOSX.icc.shared.prefix=lib
 x86_64.MacOSX.icc.static.extension=a
 x86_64.MacOSX.icc.shared.extension=dylib
 x86_64.MacOSX.icc.plugin.extension=bundle
-x86_64.MacOSX.icc.jni.extension=jnilib
+x86_64.MacOSX.icc.jni.extension=dylib
 x86_64.MacOSX.icc.executable.extension=
 
 # FIXME to be removed when NAR-6
 x86_64.MacOSX.icc.static.extension=a
 x86_64.MacOSX.icc.shared.extension=dylib
 x86_64.MacOSX.icc.plugin.extension=bundle
-x86_64.MacOSX.icc.jni.extension=jnilib
+x86_64.MacOSX.icc.jni.extension=dylib
 
-#x86_64.MacOSX.icc.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib lib/**/*.jnilib
+#x86_64.MacOSX.icc.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib
 
 #
 # MacOSX ("Mac OS X" => MacOSX) Intel (64 bits) icpc
@@ -796,16 +796,16 @@ x86_64.MacOSX.icpc.shared.prefix=lib
 x86_64.MacOSX.icpc.static.extension=a
 x86_64.MacOSX.icpc.shared.extension=dylib
 x86_64.MacOSX.icpc.plugin.extension=bundle
-x86_64.MacOSX.icpc.jni.extension=jnilib
+x86_64.MacOSX.icpc.jni.extension=dylib
 x86_64.MacOSX.icpc.executable.extension=
 
 # FIXME to be removed when NAR-6
 x86_64.MacOSX.icpc.static.extension=a
 x86_64.MacOSX.icpc.shared.extension=dylib
 x86_64.MacOSX.icpc.plugin.extension=bundle
-x86_64.MacOSX.icpc.jni.extension=jnilib
+x86_64.MacOSX.icpc.jni.extension=dylib
 
-#x86_64.MacOSX.icpc.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib lib/**/*.jnilib
+#x86_64.MacOSX.icpc.arch.includes=lib/**/*.a lib/**/*.so lib/**/*.dylib
 
 #
 # Solaris


### PR DESCRIPTION
Since Java 7 OSX JNI libraries use the extension "dylib" instead of "jnilib".  Considering Java 6 is almost completely EOL, just switching the extensions without any specialized detection of Java environment should be sufficient.