### PR TITLE
Fixing squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -214,7 +214,7 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
 
   protected final List getTests() {
     if (this.tests == null) {
-      this.tests = Collections.EMPTY_LIST;
+      this.tests = Collections.emptyList();
     }
     return this.tests;
   }

--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -236,7 +236,7 @@ public abstract class AbstractNarMojo extends AbstractMojo implements NarConstan
 
   protected final List<Library> getLibraries() {
     if (this.libraries == null) {
-      this.libraries = Collections.EMPTY_LIST;
+      this.libraries = Collections.emptyList();
     }
     return this.libraries;
   }

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -417,7 +417,7 @@ public class NarCompileMojo extends AbstractCompileMojo {
 
   private List getSourcesFor(final Compiler compiler) throws MojoFailureException, MojoExecutionException {
     if (compiler == null) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
 
     try {
@@ -431,7 +431,7 @@ public class NarCompileMojo extends AbstractCompileMojo {
       }
       return files;
     } catch (final IOException e) {
-      return Collections.EMPTY_LIST;
+      return Collections.emptyList();
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/apple/XcodeProjectWriter.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/apple/XcodeProjectWriter.java
@@ -439,7 +439,7 @@ public final class XcodeProjectWriter implements ProjectWriter {
         final PBXObjectRef referenceProxy = createPBXReferenceProxy(proxy, dependency);
         objects.put(referenceProxy.getID(), referenceProxy.getProperties());
 
-        final PBXObjectRef buildFile = createPBXBuildFile(referenceProxy, Collections.EMPTY_MAP);
+        final PBXObjectRef buildFile = createPBXBuildFile(referenceProxy, Collections.emptyMap());
         objects.put(buildFile.getID(), buildFile.getProperties());
 
         final List productsChildren = new ArrayList();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1596 -   Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1596


Please let me know if you have any questions.
Sameer Misger