### PR TITLE
Fixing squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

### DIFF
--- a/src/main/java/com/github/maven_nar/NarLogger.java
+++ b/src/main/java/com/github/maven_nar/NarLogger.java
@@ -72,10 +72,11 @@ public class NarLogger implements BuildListener {
       case Project.MSG_VERBOSE:
         this.log.debug(msg);
         break;
-      default:
       case Project.MSG_DEBUG:
         this.log.debug(msg);
         break;
+      default:
+    	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandCCompiler.java
@@ -139,6 +139,8 @@ public class BorlandCCompiler extends PrecompilingCommandLineCCompiler {
         final String outputFileName = getOutputFileNames(filename, null)[0];
         final String objectName = new File(outputDir, outputFileName).toString();
         return objectName;
+      default:
+      	break;
     }
     String relative="";
     try {

--- a/src/main/java/com/github/maven_nar/cpptasks/compaq/CompaqVisualFortranCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compaq/CompaqVisualFortranCompiler.java
@@ -102,6 +102,8 @@ public class CompaqVisualFortranCompiler extends CommandLineFortranCompiler {
       case 5:
         args.addElement("/warn:errors");
         break;
+      default:
+      	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractLinker.java
@@ -100,6 +100,8 @@ public abstract class AbstractLinker extends AbstractProcessor implements Linker
         //
       case 1:
         return 0;
+      default:
+      	break;
     }
     return bid;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -346,6 +346,8 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
         case 2:
           endCount++;
           break;
+        default:
+        	break;
       }
     }
     final String[] endArgs = new String[endCount];

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
@@ -136,6 +136,8 @@ public abstract class GccCompatibleCCompiler extends CommandLineCCompiler {
       case 3:
         args.addElement("-Wall");
         break;
+      default:
+      	break;
     }
   }
 
@@ -153,6 +155,8 @@ public abstract class GccCompatibleCCompiler extends CommandLineCCompiler {
         final String outputFileName = getOutputFileNames(filename, null)[0];
         final String objectName = new File(outputDir, outputFileName).toString();
         return objectName;
+      default:
+      	break;
     }
     String relative="";
       try {

--- a/src/main/java/com/github/maven_nar/cpptasks/hp/aCCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/hp/aCCCompiler.java
@@ -93,6 +93,8 @@ public final class aCCCompiler extends GccCompatibleCCompiler {
       case 2:
         args.addElement("+w");
         break;
+      default:
+      	break;
     /*
      * case 3: case 4: case 5: args.addElement("+w2"); break;
      */

--- a/src/main/java/com/github/maven_nar/cpptasks/ibm/VisualAgeCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/ibm/VisualAgeCCompiler.java
@@ -104,6 +104,8 @@ public final class VisualAgeCCompiler extends GccCompatibleCCompiler {
       case 5:
         args.addElement("-qhalt=w:w");
         break;
+      default:
+      	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
@@ -133,6 +133,8 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
         return "/tlb";
       case 1:
         return new File(outputDir, getOutputFileNames(filename, null)[0]).getAbsolutePath();
+      default:
+      	break;
     }
     return filename;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
@@ -140,6 +140,8 @@ public final class MsvcMessageCompiler extends CommandLineCompiler {
         return "-r";
       case 1:
         return outputDir.getAbsolutePath();
+      default:
+      	break;
     }
     return filename;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcProcessor.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcProcessor.java
@@ -46,6 +46,8 @@ public class MsvcProcessor {
       case 5:
         args.addElement("/WX");
         break;
+      default:
+      	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/parser/PostE.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/parser/PostE.java
@@ -41,6 +41,8 @@ public class PostE extends AbstractParserState {
         return this.quote;
       case '\n':
         return getParser().getNewLineState();
+      default:
+      	break;
     }
     return null;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/sun/ForteCCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/sun/ForteCCCompiler.java
@@ -107,6 +107,9 @@ public final class ForteCCCompiler extends GccCompatibleCCompiler {
       case 5:
         args.addElement("+w2");
         args.addElement("-xwe");
+        break;
+      default:
+      	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/sun/ForteCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/sun/ForteCCompiler.java
@@ -93,6 +93,8 @@ public final class ForteCCompiler extends GccCompatibleCCompiler {
       case 5:
         args.addElement("+w2");
         break;
+      default:
+      	break;
     }
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/sun/ForteF77Compiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/sun/ForteF77Compiler.java
@@ -93,6 +93,8 @@ public final class ForteF77Compiler extends GccCompatibleCCompiler {
       case 5:
         args.addElement("+w2");
         break;
+      default:
+      	break;
     }
   }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause". You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.
Sameer Misger