### PR TITLE
MSVC Intermediate output files to AOL target folder

### DIFF
--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -444,21 +444,28 @@ public class Msvc {
     File includeDir = new File(kitDirectory, "Include");
     if(includeDir.exists()){
       File libDir = new File(kitDirectory, "Lib");
-      // take the first dir in lib dir
-      libDir = libDir.listFiles()[0];
-      addSDKLibs(includeDir, libDir);
+      File usableLibDir = null;
+      for( final File libSubDir : libDir.listFiles()){
+        final File um = new File(libSubDir,"um");
+        if( um.exists())
+          usableLibDir = libSubDir;
+      }
+      if( null == usableLibDir )
+        usableLibDir = libDir.listFiles()[0];
+      
+      addSDKLibs(includeDir, usableLibDir);
       setKit(kitDirectory);
     }
   }
 
   private void addSDKLibs(File includeDir, File libdir) {
     final File[] libs = includeDir.listFiles();
-    for (final File libDir : libs) {
+    for (final File libIncludeDir : libs) {
       // <libName> <include path> <lib path>
-      if (libsRequired.remove(libDir.getName())) {
-        mojo.getLog().debug(String.format(" Using directory %1s for library %2s", libDir.getAbsolutePath(), libDir.getName()));
-        sdkIncludes.add(libDir);
-        sdkLibs.add(new File(libdir, libDir.getName()));
+      if (libsRequired.remove(libIncludeDir.getName())) {
+        mojo.getLog().debug(String.format(" Using directory %1s for library %2s", libIncludeDir.getAbsolutePath(), libIncludeDir.getName()));
+        sdkIncludes.add(libIncludeDir);
+        sdkLibs.add(new File(libdir, libIncludeDir.getName()));
       }
     }
   }

--- a/src/main/java/com/github/maven_nar/NarLayout21.java
+++ b/src/main/java/com/github/maven_nar/NarLayout21.java
@@ -239,12 +239,11 @@ public class NarLayout21 extends AbstractNarLayout {
     } else if (!dir.exists()) {
       process = true;
     } else if (file.lastModified() > dir.lastModified()) {
-      try {
-        FileUtils.deleteDirectory(dir);
-      } catch (final IOException e) {
-        throw new MojoExecutionException("Could not delete directory: " + dir, e);
-      }
-
+      NarUtil.deleteDirectory(dir);
+      process = true;
+    } else if (unpackDirectory.list().length == 0) {
+      // a previously failed cleanup which failed deleting all may have left a
+      // state where dir modified > file modified but not unpacked.
       process = true;
     }
 
@@ -252,4 +251,5 @@ public class NarLayout21 extends AbstractNarLayout {
       unpackNarAndProcess(archiverManager, file, dir, os, linkerName, defaultAOL);
     }
   }
+
 }

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -188,6 +188,26 @@ public final class NarUtil {
     return copied;
   }
 
+  public static void deleteDirectory(final File dir) throws MojoExecutionException {
+    int retries = OS.WINDOWS.equalsIgnoreCase(System.getProperty("os.name")) ? 3 : 1;  // Windows file locking (such as due to virus scanners) and sometimes deleting slowly, or slow to report completion.
+    while (retries > 0) {
+      retries--;
+      try {
+        FileUtils.deleteDirectory(dir);
+      } catch (final IOException e) {
+        if (retries > 0) {
+//          getLog().info("Could not delete directory: " + dir + " : Retrying");
+          Thread.yield();
+        } else {
+          throw new MojoExecutionException("Could not delete directory: " + dir, e);
+        }
+      }
+      //TODO: if( windows and interactive ) prompt for retry?
+      //@Component(role=org.codehaus.plexus.components.interactivity.Prompter.class, hint="archetype")
+      //public class ArchetypePrompter
+    }
+  }
+  
   static Set findInstallNameToolCandidates(final File[] files, final Log log)
       throws MojoExecutionException, MojoFailureException {
     final HashSet candidates = new HashSet();

--- a/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandResourceCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/borland/BorlandResourceCompiler.java
@@ -146,13 +146,6 @@ public class BorlandResourceCompiler extends CommandLineCompiler {
   }
 
   @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    return arg1.length() + arg2.length() + 2;
-  }
-
-  @Override
   protected void getUndefineSwitch(final StringBuffer buffer, final String define) {
   }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -538,8 +538,22 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     return Integer.MAX_VALUE;
   }
 
+  /**
+   * Get total command line length due to the input file.
+   * 
+   * @param outputDir
+   *          File output directory
+   * @param inputFile
+   *          String input file
+   * @return int characters added to command line for the input file.
+   */
   protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    return inputFile.length() + 1;
+    final int argumentCountPerInputFile = getArgumentCountPerInputFile();
+    int len=0;
+    for (int k = 0; k < argumentCountPerInputFile; k++) {
+      len+=getInputFileArgument(outputDir, inputFile, k).length();
+    }
+    return len + argumentCountPerInputFile; // argumentCountPerInputFile added for spaces
   }
 
   abstract protected void getUndefineSwitch(StringBuffer buffer, String define);

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/WindresResourceCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/WindresResourceCompiler.java
@@ -138,13 +138,6 @@ public final class WindresResourceCompiler extends CommandLineCompiler {
   }
 
   @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    return arg1.length() + arg2.length() + 2;
-  }
-
-  @Override
   protected void getUndefineSwitch(final StringBuffer buffer, final String define) {
     buffer.append("-U");
     buffer.append(define);

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcCompatibleCCompiler.java
@@ -60,10 +60,14 @@ public abstract class MsvcCompatibleCCompiler extends PrecompilingCommandLineCCo
 
   protected void addDebugSwitch(final Vector<String> args) {
     args.addElement("/Zi");
-    args.addElement("/Fd" + objDir.getAbsolutePath() + File.separator);
     args.addElement("/Od");
     args.addElement("/RTC1");
     args.addElement("/D_DEBUG");
+  }
+
+  protected void addPathSwitch(final Vector<String> args) {
+    args.addElement("/Fd" + objDir.getAbsolutePath() + File.separator); // vc[version].pdb
+    args.addElement("/Fa" + objDir.getAbsolutePath() + File.separator);
   }
 
   @Override
@@ -110,6 +114,7 @@ public abstract class MsvcCompatibleCCompiler extends PrecompilingCommandLineCCo
       // /GR- to disable it
       args.addElement("/GR-");
     }
+    addPathSwitch(args);
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
@@ -159,16 +159,6 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
   }
 
   @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final int argumentCountPerInputFile = getArgumentCountPerInputFile();
-    int len=0;
-    for (int k = 0; k < argumentCountPerInputFile; k++) {
-      len+=getInputFileArgument(outputDir, inputFile, k).length();
-    }
-    return len + argumentCountPerInputFile; // argumentCountPerInputFile added for spaces
-  }
-
-  @Override
   protected void getUndefineSwitch(final StringBuffer buffer, final String define) {
     MsvcProcessor.getUndefineSwitch(buffer, define);
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMIDLCompiler.java
@@ -94,7 +94,7 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
 
   @Override
   protected int getArgumentCountPerInputFile() {
-    return 3;
+    return 5;
   }
 
   @Override
@@ -133,6 +133,11 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
         return "/tlb";
       case 1:
         return new File(outputDir, getOutputFileNames(filename, null)[0]).getAbsolutePath();
+      case 2:
+        return "/out";
+      case 3:
+        return outputDir.getAbsolutePath();
+       
     }
     return filename;
   }
@@ -155,10 +160,12 @@ public final class MsvcMIDLCompiler extends CommandLineCompiler {
 
   @Override
   protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    final String arg3 = getInputFileArgument(outputDir, inputFile, 2);
-    return arg1.length() + arg2.length() + arg3.length() + 3;
+    final int argumentCountPerInputFile = getArgumentCountPerInputFile();
+    int len=0;
+    for (int k = 0; k < argumentCountPerInputFile; k++) {
+      len+=getInputFileArgument(outputDir, inputFile, k).length();
+    }
+    return len + argumentCountPerInputFile; // argumentCountPerInputFile added for spaces
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
@@ -163,17 +163,6 @@ public final class MsvcMessageCompiler extends CommandLineCompiler {
     return 1;
   }
 
-  
-  @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final int argumentCountPerInputFile = getArgumentCountPerInputFile();
-    int len=0;
-    for (int k = 0; k < argumentCountPerInputFile; k++) {
-      len+=getInputFileArgument(outputDir, inputFile, k).length();
-    }
-    return len + argumentCountPerInputFile; // argumentCountPerInputFile added for spaces
-  }
-
   @Override
   protected void getUndefineSwitch(final StringBuffer buffer, final String define) {
     MsvcProcessor.getUndefineSwitch(buffer, define);

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcMessageCompiler.java
@@ -110,7 +110,7 @@ public final class MsvcMessageCompiler extends CommandLineCompiler {
 
   @Override
   protected int getArgumentCountPerInputFile() {
-    return 3;
+    return 5;
   }
 
   @Override
@@ -140,6 +140,10 @@ public final class MsvcMessageCompiler extends CommandLineCompiler {
         return "-r";
       case 1:
         return outputDir.getAbsolutePath();
+      case 2:
+        return "-h";
+      case 3:
+        return outputDir.getAbsolutePath();
     }
     return filename;
   }
@@ -159,11 +163,15 @@ public final class MsvcMessageCompiler extends CommandLineCompiler {
     return 1;
   }
 
+  
   @Override
   protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    return arg1.length() + arg2.length() + 2;
+    final int argumentCountPerInputFile = getArgumentCountPerInputFile();
+    int len=0;
+    for (int k = 0; k < argumentCountPerInputFile; k++) {
+      len+=getInputFileArgument(outputDir, inputFile, k).length();
+    }
+    return len + argumentCountPerInputFile; // argumentCountPerInputFile added for spaces
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcResourceCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/MsvcResourceCompiler.java
@@ -138,13 +138,6 @@ public final class MsvcResourceCompiler extends CommandLineCompiler {
   }
 
   @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    return arg1.length() + arg2.length() + 2;
-  }
-
-  @Override
   protected void getUndefineSwitch(final StringBuffer buffer, final String define) {
     MsvcProcessor.getUndefineSwitch(buffer, define);
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/trolltech/MetaObjectCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/trolltech/MetaObjectCompiler.java
@@ -300,22 +300,6 @@ public final class MetaObjectCompiler extends CommandLineCompiler {
   }
 
   /**
-   * Get total command line length due to the input file.
-   * 
-   * @param outputDir
-   *          File output directory
-   * @param inputFile
-   *          String input file
-   * @return int characters added to command line for the input file.
-   */
-  @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 0);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 1);
-    return arg1.length() + arg2.length() + 3;
-  }
-
-  /**
    * Gets switch to undefine preprocessor macro.
    * 
    * @param buffer

--- a/src/main/java/com/github/maven_nar/cpptasks/trolltech/UserInterfaceCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/trolltech/UserInterfaceCompiler.java
@@ -365,22 +365,6 @@ public final class UserInterfaceCompiler extends CommandLineCompiler {
   }
 
   /**
-   * Get total command line length due to the input file.
-   * 
-   * @param outputDir
-   *          File output directory
-   * @param inputFile
-   *          String input file
-   * @return int characters added to command line for the input file.
-   */
-  @Override
-  protected int getTotalArgumentLengthForInputFile(final File outputDir, final String inputFile) {
-    final String arg1 = getInputFileArgument(outputDir, inputFile, 1);
-    final String arg2 = getInputFileArgument(outputDir, inputFile, 2);
-    return arg1.length() + arg2.length() + 4;
-  }
-
-  /**
    * Gets switch to undefine preprocessor macro.
    * 
    * @param buffer

--- a/src/test/java/com/github/maven_nar/cpptasks/TestCompilerDef.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/TestCompilerDef.java
@@ -206,6 +206,8 @@ public final class TestCompilerDef extends TestProcessorDef {
     setCompilerName(extendedCompiler, "msvc");
     final CCTask cctask = new CCTask();
     final LinkType linkType = new LinkType();
+    final File objDir = new File("dummy");
+    cctask.setObjdir(objDir);
     linkType.setStaticRuntime(true);
     final CommandLineCompilerConfiguration config = (CommandLineCompilerConfiguration) extendedCompiler
         .createConfiguration(cctask, linkType, null, null, null);

--- a/src/test/java/com/github/maven_nar/cpptasks/TestProcessorDef.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/TestProcessorDef.java
@@ -82,6 +82,8 @@ public abstract class TestProcessorDef extends TestCase {
   protected final ProcessorConfiguration getConfiguration(final ProcessorDef extendedProcessor) {
     final CCTask cctask = new CCTask();
     final LinkType linkType = new LinkType();
+    final File objDir = new File("dummy");
+    cctask.setObjdir(objDir);
     return extendedProcessor.createConfiguration(cctask, linkType, null, null, null);
   }
 

--- a/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvcCCompiler.java
+++ b/src/test/java/com/github/maven_nar/cpptasks/msvc/TestMsvcCCompiler.java
@@ -39,11 +39,10 @@ public class TestMsvcCCompiler extends TestCase {
     final File objDir = new File("dummy");
     compiler.setObjDir(objDir);
     compiler.addDebugSwitch(args);
-    assertEquals(5, args.size());
+    assertEquals(4, args.size());
     assertEquals("/Zi", args.elementAt(0));
-    assertEquals("/Fd" + objDir.getAbsolutePath() + File.separator, args.elementAt(1));
-    assertEquals("/Od", args.elementAt(2));
-    assertEquals("/RTC1", args.elementAt(3));
-    assertEquals("/D_DEBUG", args.elementAt(4));
+    assertEquals("/Od", args.elementAt(1));
+    assertEquals("/RTC1", args.elementAt(2));
+    assertEquals("/D_DEBUG", args.elementAt(3));
   }
 }


### PR DESCRIPTION
With change to build working dir, so that building from src folders rather than AOL nar/obj folder or nar-test/obj,  some additional settings needed to be made for msvc output locations.

Also I got tired of Windows delete failing for NarUnpack and leaving an empty folder thats been modified so that Unpack doesn't try again without having to manually go and delete from the narunpack folder.