### PR TITLE
Avoid compiler/linker double logging

### DIFF
--- a/src/main/java/com/github/maven_nar/NarLogger.java
+++ b/src/main/java/com/github/maven_nar/NarLogger.java
@@ -62,7 +62,6 @@ public class NarLogger implements BuildListener {
         this.log.warn(msg);
         break;
       case Project.MSG_INFO:
-        this.log.info(msg);
         if (msg.indexOf("error") >= 0) {
           this.log.error(msg);
         } else {


### PR DESCRIPTION
At present moment compiler and linker provide log messages twice:
```
[INFO] Compiling 1 native files
[INFO] 1 total files to be compiled.
[INFO] 1 total files to be compiled.
[INFO] Found 4 processors available
[INFO] Found 4 processors available
[INFO] Limited used processors to 1
[INFO] Limited used processors to 1
[INFO]
Starting Core 0 with 1 source files...
[INFO]
Starting Core 0 with 1 source files...
[INFO] Linking...
[INFO] Linking...
```
Due to this small fix NarLogger prints info messages only once.

Signed-off-by: Dmitry Kirsanov