### PR TITLE
static binding not picked up when built for both executable and static libs

### DIFF
--- a/src/main/java/com/github/maven_nar/NarLayout21.java
+++ b/src/main/java/com/github/maven_nar/NarLayout21.java
@@ -199,8 +199,8 @@ public class NarLayout21 extends AbstractNarLayout {
           narInfo.setLibs(aol, mojo.getLibsName());
         }
 
-        // We prefer libs of shared & static to jni/executable/none,
-        if ( (type.equals(Library.SHARED)) || (type.equals(Library.STATIC)) ) // overwrite whatever we had
+        // We prefer shared to jni/executable/static/none,
+        if (type.equals(Library.SHARED)) // overwrite whatever we had
         {
           narInfo.setBinding(aol, type);
           narInfo.setBinding(null, type);
@@ -209,7 +209,15 @@ public class NarLayout21 extends AbstractNarLayout {
           // jni/executable/none.
           if (narInfo.getBinding(aol, null) == null) {
             narInfo.setBinding(aol, type);
+          } else {
+            //static lib is preferred over other remaining types; see #231
+            if (type.equals(Library.STATIC))
+            {
+              narInfo.setBinding(aol, type);
+              narInfo.setBinding(null, type);
+            }
           }
+
           if (narInfo.getBinding(null, null) == null) {
             narInfo.setBinding(null, type);
           }

--- a/src/main/java/com/github/maven_nar/NarLayout21.java
+++ b/src/main/java/com/github/maven_nar/NarLayout21.java
@@ -199,14 +199,14 @@ public class NarLayout21 extends AbstractNarLayout {
           narInfo.setLibs(aol, mojo.getLibsName());
         }
 
-        // We prefer shared to jni/executable/static/none,
-        if (type.equals(Library.SHARED)) // overwrite whatever we had
+        // We prefer libs of shared & static to jni/executable/none,
+        if ( (type.equals(Library.SHARED)) || (type.equals(Library.STATIC)) ) // overwrite whatever we had
         {
           narInfo.setBinding(aol, type);
           narInfo.setBinding(null, type);
         } else {
           // if the binding is already set, then don't write it for
-          // jni/executable/static/none.
+          // jni/executable/none.
           if (narInfo.getBinding(aol, null) == null) {
             narInfo.setBinding(aol, type);
           }


### PR DESCRIPTION
This is push is as per #230  and https://groups.google.com/forum/#!topic/maven-nar/Ig9yc8LPwxA

I have tested it on CentOs7.2 i386 vm and All NAR IT tests seem to pass except one "it0002-executable-static". This test also fails for original code due to non resolution of static -lstdc++ & others..

[INFO] -------------------------------------------------
[INFO] Build Summary:
[INFO] Passed: 25, Failed: 1, Errors: 0, Skipped: 0
[INFO] -------------------------------------------------
[ERROR] The following builds failed:
[ERROR] * it0002-executable-static/pom.xml
[INFO] -------------------------------------------------

please comment..

Thanks
Mano
