### PR TITLE
Correction for mingw on Windows.

### DIFF
--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -191,7 +191,7 @@ public class Msvc {
 
   private void init() throws MojoFailureException, MojoExecutionException {
     final String mojoOs = this.mojo.getOS();
-    if (NarUtil.isWindows() && OS.WINDOWS.equals(mojoOs)) {
+    if (NarUtil.isWindows() && OS.WINDOWS.equals(mojoOs) && "msvc".equalsIgnoreCase(mojo.getLinker().getName())) {
       windowsHome = new File(System.getenv("SystemRoot"));
       initVisualStudio();
       initWindowsSdk();


### PR DESCRIPTION
nar-maven-plugin doesn't work anymore on Windows with mingw **if
VisualStudio isn't installed**, because it tries to run the msvc command
"link" during the initialization of the class Msvc in
AbstractNarMojo.validate() (even if we don't use msvc).

Correction : in Msvc.init() I make the same test
"msvc".equalsIgnoreCase(mojo.getLinker().getName()) than in other
methods of the class (configureCCTask and configureLinker for example).
This way if the name of the linker if forced to "g++" in the pom (for
mingw), Msvc.init() doesn't do anything as if we were not on Windows and
thus doesn't quit on error.