### PR TITLE
GCC WindresResourceCompiler, bad output folder for objects.

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/WindresResourceCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/WindresResourceCompiler.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.Vector;
 
 import org.apache.tools.ant.types.Environment;
+import org.apache.tools.ant.util.FileUtils;
 
 import com.github.maven_nar.cpptasks.OptimizationEnum;
 import com.github.maven_nar.cpptasks.compiler.CommandLineCompiler;
@@ -117,9 +118,19 @@ public final class WindresResourceCompiler extends CommandLineCompiler {
   protected String getInputFileArgument(final File outputDir, final String filename, final int index) {
     if (index == 0) {
       final String outputFileName = getOutputFileNames(filename, null)[0];
-      return "-o" + outputFileName;
+      final String objectName = new File(outputDir, outputFileName).toString();
+      return "-o" + objectName;
     }
-    return filename;
+    String relative="";
+    try {
+        relative = FileUtils.getRelativePath(workDir, new File(filename));
+    } catch (Exception ex) {
+    }
+    if (relative.isEmpty()) {
+        return filename;
+    } else {
+        return relative;
+    }
   }
 
   @Override


### PR DESCRIPTION
The method getInputFileArgument of the Compiler classes returns the
arguments to pass to the compiler based on the input files. On
WindresResourceCompiler the resulting arguments are
`-o<resource_filename_wo_ext>.<hash>.o <resource_fullpath>` :
* `<resource_filename_wo_ext>` = resource filename without path and
without extension.
* `<resource_fullpath>` = resource filename with its full path.

The object file is generated in `src/main/` and the linker exits then on error because it doesn't find the object file in the directory `target/nar/obj/<aol>/`

The method WindresResourceCompiler.getInputFileArgument is modified to
generate the command arguments
`-o<obj_fullpath>.<hash>.o <resource_relativepath>` :
* `<obj_fullpath>` : filename with full path for object files.
* `<resource_relativepath>` : resource filename with its relative path.

I took example on GccCompatibleCCompiler.getInputFileArgument.