### PR TITLE
#244 : full path to Source filenames added only to gcc builds.

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -86,6 +86,16 @@ public abstract class Compiler {
   private File testSourceDirectory;
 
   /**
+   * To use full path for the filenames.
+   * false to have "relative" path
+   * true to have "absolute" path
+   * absolute: will give path from filesystem root "/"
+   * relative: will give relative path from "workdir" which is usually after "${basedir}/src/main"
+   */
+  @Parameter(required = true)
+  private boolean gccFileAbsolutePath = false;
+
+  /**
    * Include patterns for sources
    */
   @Parameter(required = true)
@@ -483,6 +493,9 @@ public abstract class Compiler {
         compilerDef.setWorkDir(this.sourceDirectory);
       }
     }
+
+    compilerDef.setGccFileAbsolutePath(this.gccFileAbsolutePath);
+
     return compilerDef;
   }
 

--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -1232,6 +1232,7 @@ public class CCTask extends Task {
         CommandLineCompilerConfiguration commandLineConfig = (CommandLineCompilerConfiguration) config;
         AbstractCompiler compiler = (AbstractCompiler) commandLineConfig.getCompiler();
         compiler.setWorkDir(currentCompilerDef.getWorkDir());
+        compiler.setGccFileAbsolutePath(currentCompilerDef.getGccFileAbsolutePath());
         ProcessorConfiguration[] localConfigs = new ProcessorConfiguration[] {
           config
         };

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -61,6 +61,7 @@ public final class CompilerDef extends ProcessorDef {
   private String toolPath;
   private String compilerPrefix;
   private File workDir;
+  private boolean gccFileAbsolutePath;
 
   private boolean clearDefaultOptions;
 
@@ -577,5 +578,14 @@ public final class CompilerDef extends ProcessorDef {
    */
   public void setWarnings(final WarningLevelEnum level) {
     this.warnings = level.getIndex();
+  }
+
+  public void setGccFileAbsolutePath(final boolean sourceFileAbsPath) {
+    this.gccFileAbsolutePath = sourceFileAbsPath;
+    return;
+  }
+
+  public boolean getGccFileAbsolutePath() {
+    return this.gccFileAbsolutePath;
   }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractCompiler.java
@@ -48,6 +48,7 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
   private final String outputSuffix;
   protected File workDir;
   protected File objDir;
+  protected boolean gccFileAbsolutePath;
 
   protected AbstractCompiler(final String[] sourceExtensions, final String[] headerExtensions, final String outputSuffix) {
     super(sourceExtensions, headerExtensions);
@@ -205,6 +206,10 @@ public abstract class AbstractCompiler extends AbstractProcessor implements Comp
 
   public void setWorkDir(final File workDir) {
     this.workDir = workDir;
+  }
+
+  public void setGccFileAbsolutePath(final boolean gccFileAbsolutePath) {
+    this.gccFileAbsolutePath = gccFileAbsolutePath;
   }
 
   public void setObjDir(final File objDir) {

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccCompatibleCCompiler.java
@@ -154,16 +154,21 @@ public abstract class GccCompatibleCCompiler extends CommandLineCCompiler {
         final String objectName = new File(outputDir, outputFileName).toString();
         return objectName;
     }
-    String relative="";
+    String relative = "";
+    if ( this.gccFileAbsolutePath) {
+      return filename;
+    } else {
       try {
-          relative = FileUtils.getRelativePath(workDir, new File(filename));
+        relative = FileUtils.getRelativePath(workDir, new File(filename));
       } catch (Exception ex) {
       }
-      if (relative.isEmpty()) {
-          return filename;
-      } else {
-          return relative;
-      }
+    }
+	
+    if (relative.isEmpty()) {
+      return filename;
+    } else {
+      return relative;
+    }
   }
 
   @Override


### PR DESCRIPTION
This pull request is to fix #244 issue of having full path to filenames in gcc builds with a new NAR parameter.

Main code change is to use full path in `getInputFileArgument`  based on the `gccFileAbsolutePath`  flag .

I have only added logic to`GccCompatibleCCompiler.java` as this fix is intended only for gcc. 
Same fix can be applied to other compilers too by adding logic to corresponding files below. But for me I don't have a way to test them.

```
borland/BorlandCCompiler.java
borland/BorlandResourceCompiler.java
gcc/WindresResourceCompiler.java
mozilla/XpidlCompiler.java
msvc/MsvcCompatibleCCompiler.java
msvc/MsvcMessageCompiler.java
msvc/MsvcMIDLCompiler.java
msvc/MsvcResourceCompiler.java
trolltech/MetaObjectCompiler.java
trolltech/UserInterfaceCompiler.java
```

This issue is also related to  #205  and to #158 issues.

To set `gccFileAbsolutePath`  flag `true` you need below NAR configuration pom update.

``` xml
        <cpp combine.children="append">
         <gccFileAbsolutePath>true</gccFileAbsolutePath>
         </cpp>
         <c combine.children="append">
         <gccFileAbsolutePath>true</gccFileAbsolutePath>
         </c>
```

This fix behaves exactly as before until `gccFileAbsolutePath`  flag is set to `true`. 

I have tested with `mvn clean install -Prun-its` for both `gccFileAbsolutePath` true & false and seem to be fine on my VM which is `Centos 7 x86 32bit`
