### PR TITLE
AIX 64 bits- Add support to compiling g++ on AIX Platform

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>

--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -49,6 +49,13 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
   @Parameter
   private Fortran fortran;
 
+    /**
+     * Assembler Compiler
+     *
+     */
+    @Parameter
+    private Assembler assembler;
+
   /**
    * Resource Compiler
    */
@@ -170,6 +177,16 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
     }
     return this.fortran;
   }
+
+    protected final Assembler getAssembler()
+    {
+        if ( assembler == null )
+        {
+            assembler = new Assembler();
+        }
+        assembler.setAbstractCompileMojo( this );
+        return assembler;
+    }
 
   protected final IDL getIdl() {
     if (this.idl == null && !this.onlySpecifiedCompilers) {

--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -65,7 +65,7 @@ public abstract class AbstractNarMojo extends AbstractMojo implements NarConstan
 
   /**
    * The Operating System for the nar. Some choices are: "Windows", "Linux",
-   * "MacOSX", "SunOS", ... Defaults to a
+   * "MacOSX", "SunOS", "AIX",... Defaults to a
    * derived value from ${os.name} FIXME table missing
    */
   @Parameter(property = "nar.os")

--- a/src/main/java/com/github/maven_nar/Assembler.java
+++ b/src/main/java/com/github/maven_nar/Assembler.java
@@ -1,0 +1,38 @@
+package com.github.maven_nar;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Assembler  compiler tag
+ * 
+ * @author Mark Donszelmann
+ */
+public class Assembler
+    extends Compiler
+{
+    public Assembler()
+    {
+    }
+
+    public final String getLanguage()
+    {
+        return "asm";
+    }
+}

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -36,7 +36,18 @@ public class Msvc {
 
   private final Set<String> paths = new LinkedHashSet<>();
 
-  @Parameter
+    /**
+     * VisualStudio Linker version required, the values should be-
+     *      7.1 for VS 2003
+     *      8.0 for VS 2005
+     *      9.0  for VS 2008
+     *     10.0   for VS 2010
+     *     11.0   for VS 2012
+     *      12.00  for VS 2013
+     *     14.0  for VS 2015
+     *     15.0 for VS 2017
+     */
+  @Parameter(defaultValue = "")
   private String version;
 
   @Parameter
@@ -110,12 +121,26 @@ public class Msvc {
       addIncludePath(task, this.home, "VC/include");
       addIncludePath(task, this.home, "VC/atlmfc/include");
       if (compareVersion(this.windowsSdkVersion, "7.1A") <= 0) {
-        addIncludePath(task, this.windowsSdkHome, "include");
-      } else {
-        for (File sdkInclude : sdkIncludes)
-          addIncludePathToTask(task, sdkInclude);
-
+		  if(this.version.equals("8.0"))
+		  { // For VS 2005 the version of SDK is 2.0, but it needs more paths
+				 for (File sdkInclude : sdkIncludes)      {
+				addIncludePathToTask(task, sdkInclude);
+				mojo.getLog().debug(" configureCCTask add to Path-- " + sdkInclude.getAbsolutePath());
+			} 
+		  }
+		  else
+		  {
+			addIncludePath(task, this.windowsSdkHome, "include");  
+		  }
+			
+      } 
+	  
+	  else {
+        for (File sdkInclude : sdkIncludes)      {
+            addIncludePathToTask(task, sdkInclude);
+        }
       }
+	  
       task.addEnv(getPathVariable());
       // TODO: supporting running with clean environment - addEnv sets
       // newEnvironemnt by default
@@ -151,6 +176,7 @@ public class Msvc {
         linker.addLibraryDirectory(this.home, "VC/lib/" + arch);
         linker.addLibraryDirectory(this.home, "VC/atlmfc/lib/" + arch);
       }
+	   
       // Windows SDK
       String sdkArch = arch;
       if ("amd64".equals(arch)) {
@@ -205,8 +231,17 @@ public class Msvc {
 	  windowsHome = new File(System.getenv("SystemRoot"));
 	  
       initVisualStudio();
-      initWindowsSdk();
-      initPath();
+        if (this.version.equals("8.0"))
+        {  // VS 2005 works with build in Windows SDK
+            initWindowsSdk8();
+            initPath8();
+        }
+        else
+        {
+                initWindowsSdk();
+                 initPath();
+        }
+
     } else {
       this.version = "";
       this.windowsSdkVersion = "";
@@ -275,8 +310,19 @@ public class Msvc {
     addPath(this.windowsHome, "System32/wbem");
   }
 
+    private void initPath8() throws MojoExecutionException {
+     
+        // clearing the path, add back the windows system folders
+        addPath(this.windowsHome, "System32");
+        addPath(this.windowsHome, "");
+        addPath(this.windowsHome, "System32/wbem");
+    }
+
   private void initVisualStudio() throws MojoFailureException, MojoExecutionException {
     mojo.getLog().debug(" -- Searching for usable VisualStudio ");
+
+      mojo.getLog().debug("Linker version is  " + this.version);
+
     if (this.version != null && this.version.trim().length() > 1) {
       String internalVersion;
       Pattern r = Pattern.compile("(\\d+)\\.*(\\d)");
@@ -384,6 +430,7 @@ public class Msvc {
     }
   };
   private boolean foundSDK = false;
+
   private void initWindowsSdk() throws MojoExecutionException {
     if(this.windowsSdkVersion != null && this.windowsSdkVersion.trim().equals(""))
       this.windowsSdkVersion = null;
@@ -492,23 +539,34 @@ public class Msvc {
     }
   }
 
+    private void initWindowsSdk8() throws MojoExecutionException {
+
+        final String osArchitecture = NarUtil.getArchitecture(null);
+        //VS 2005 - The SDK files are included in the VS installation-
+		File VCINSTALLDIR= new File (this.home,"VC");
+		
+		//File VSLibDir = new File(VCINSTALLDIR.getAbsolutePath()+File.separator+ "lib" , osArchitecture);
+		
+        File PlatformSDKIncludeDir = new File(VCINSTALLDIR.getAbsolutePath()+ File.separator+ "PlatformSDK", "include");
+		File SDKIncludeDir = new File(VCINSTALLDIR.getAbsolutePath()+ File.separator+ "SDK"+ File.separator+ "v2.0", "include");
+		
+		sdkIncludes.add(PlatformSDKIncludeDir);
+		sdkIncludes.add(SDKIncludeDir);
+		this.windowsSdkHome = this.home;
+		
+    }
+
   public void setMojo(final AbstractNarMojo mojo) throws MojoFailureException, MojoExecutionException {
       if (mojo != this.mojo) {
       this.mojo = mojo;
       init();
     }
-      else {
-          if( isMSVC(mojo) && (this.windowsHome== null))
-          {     //If the variables were not initialized yet
-              init();
-          }
 
-      }
   }
 
   @Override
   public String toString() {
-    return this.home + "\n" + this.windowsSdkHome;
+    return "VS Home-"+ this.home + "\nSDKHome-" + this.windowsSdkHome;
   }
 
   public String getToolPath() {

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -100,10 +100,12 @@ public class Msvc {
   }
 
   static boolean isMSVC(final String name) {
+	
     return "msvc".equalsIgnoreCase(name);
   }
 
   public void configureCCTask(final CCTask task) throws MojoExecutionException {
+
     if (OS.WINDOWS.equals(mojo.getOS()) && isMSVC(mojo)) {
       addIncludePath(task, this.home, "VC/include");
       addIncludePath(task, this.home, "VC/atlmfc/include");
@@ -137,6 +139,7 @@ public class Msvc {
 
   public void configureLinker(final LinkerDef linker) throws MojoExecutionException {
     final String os = mojo.getOS();
+
     if (os.equals(OS.WINDOWS) && isMSVC(mojo)) {
       final String arch = mojo.getArchitecture();
 
@@ -199,13 +202,15 @@ public class Msvc {
   private void init() throws MojoFailureException, MojoExecutionException {
     final String mojoOs = this.mojo.getOS();
     if (NarUtil.isWindows() && OS.WINDOWS.equals(mojoOs) && isMSVC(mojo)) {
-      windowsHome = new File(System.getenv("SystemRoot"));
+	  windowsHome = new File(System.getenv("SystemRoot"));
+	  
       initVisualStudio();
       initWindowsSdk();
       initPath();
     } else {
       this.version = "";
       this.windowsSdkVersion = "";
+        this.windowsHome = null;
     }
   }
 
@@ -488,10 +493,17 @@ public class Msvc {
   }
 
   public void setMojo(final AbstractNarMojo mojo) throws MojoFailureException, MojoExecutionException {
-    if (mojo != this.mojo) {
+      if (mojo != this.mojo) {
       this.mojo = mojo;
       init();
     }
+      else {
+          if( isMSVC(mojo) && (this.windowsHome== null))
+          {     //If the variables were not initialized yet
+              init();
+          }
+
+      }
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -177,6 +177,22 @@ public class NarCompileMojo extends AbstractCompileMojo {
       }
     }
 
+      if(getOS().equals( OS.WINDOWS ) && getArchitecture().equals("amd64"))
+      {
+
+          int noOfASMSources = getSourcesFor(getAssembler()).size();
+
+          if(noOfASMSources > 0)
+          {  // Assmbler files exist
+
+              CompilerDef assembler = getAssembler().getCompiler( Compiler.MAIN, null );
+
+              // CompilerDef msAssembler64bitCompiler = MSAssmbler64bitCompiler.getCompiler(Compiler.MAIN, getOutput( ),getAntProject() );
+               task.addConfiguredCompiler( assembler );
+          }
+
+      }
+
     // Darren Sargent Feb 11 2010: Use Compiler.MAIN for "type"...appears the
     // wrong "type" variable was being used
     // since getCompiler() expects "main" or "test", whereas the "type" variable
@@ -447,6 +463,11 @@ public class NarCompileMojo extends AbstractCompileMojo {
     noOfSources += getSourcesFor(getCpp()).size();
     noOfSources += getSourcesFor(getC()).size();
     noOfSources += getSourcesFor(getFortran()).size();
+      if(getOS().equals( OS.WINDOWS ) && getArchitecture().equals("amd64"))
+      {
+          noOfSources += getSourcesFor(getAssembler()).size();
+      }
+
     if (noOfSources > 0) {
       getLog().info("Compiling " + noOfSources + " native files");
       for (final Library library : getLibraries()) {

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -364,6 +364,15 @@ public final class NarUtil {
       if (name.equals("mac os x")) {
         os = OS.MACOSX;
       }
+        if ( name.equals( "AIX" ) )
+        {
+            os = OS.AIX;
+        }
+        if ( name.equals( "SunOS" ) )
+        {
+            os = OS.SUNOS;
+        }
+
     }
     return os;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -406,7 +406,7 @@ public class CCTask extends Task {
   }
 
   /**
-   * Adds desriptive version information to be included in the
+   * Adds descriptive version information to be included in the
    * generated file. The first active version info block will
    * be used.
    */

--- a/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
@@ -400,7 +400,8 @@ public class CUtil {
       final boolean newEnvironment, final Environment env) throws BuildException {
     try {
       task.log(Commandline.toString(cmdline), task.getCommandLogLevel());
-      final Execute exe = new Execute(new LogStreamHandler(task, Project.MSG_INFO, Project.MSG_ERR));
+
+     /* final Execute exe = new Execute(new LogStreamHandler(task, Project.MSG_INFO, Project.MSG_ERR));
       if (System.getProperty("os.name").equals("OS/390")) {
         exe.setVMLauncher(false);
       }
@@ -418,6 +419,8 @@ public class CUtil {
       }
       exe.setNewenvironment(newEnvironment);
       return exe.execute();
+            */
+	  return CommandExecution.runCommand(cmdline,workingDir,task);
     } catch (final java.io.IOException exc) {
       throw new BuildException("Could not launch " + cmdline[0] + ": " + exc, task.getLocation());
     }

--- a/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
@@ -1,4 +1,4 @@
-package net.sf.antcontrib.cpptasks;
+package com.github.maven_nar.cpptasks;
 
 
 import org.apache.tools.ant.Project;

--- a/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
@@ -1,0 +1,93 @@
+package net.sf.antcontrib.cpptasks;
+
+
+import org.apache.tools.ant.Project;
+
+import java.io.*;
+
+
+class StreamGobbler extends Thread {
+    InputStream is;
+    String type;
+    CCTask task;
+
+
+    StreamGobbler(InputStream is, String type, CCTask task) {
+        this.is = is;
+        this.type = type;
+        this.task = task;
+    }
+
+
+    public void run() {
+        try {
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String line;
+            while ((line = br.readLine()) != null)
+                task.log(type +">"+ line );
+
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+
+
+    }
+}
+
+
+public class CommandExecution {
+
+
+
+
+    public static int runCommand(String[] cmdArgs, File workDir, CCTask task) throws  IOException{
+
+
+        try {
+
+            //Create ProcessBuilder with the command arguments
+            ProcessBuilder pb = new ProcessBuilder(cmdArgs);
+
+            //Redirect the stderr to the stdout
+            pb.redirectErrorStream(true);
+
+            pb.directory(workDir);
+
+            //Start the new process
+            Process process = pb.start();
+
+
+            // Adding to log the command
+            StringBuilder builder = new StringBuilder();
+            for(String s : cmdArgs) {
+
+                builder.append(s);
+                //Append space
+                builder.append(" ");
+            }
+            task.log("Executing - " + builder.toString(), Project.MSG_INFO);
+
+
+            //Create the StreamGobbler to read the process output
+            StreamGobbler outputGobbler = new StreamGobbler(process.getInputStream(), "OUTPUT",task);
+
+            outputGobbler.start();
+
+            int exit_value;
+
+            //Wait for the process to finish
+            exit_value = process.waitFor();
+
+
+            return exit_value;
+
+        } catch (InterruptedException e) {
+
+            e.printStackTrace();
+            return -2;
+        }
+
+    }
+
+}

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerEnum.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerEnum.java
@@ -43,6 +43,7 @@ import com.github.maven_nar.cpptasks.msvc.MsvcCCompiler;
 import com.github.maven_nar.cpptasks.msvc.MsvcMIDLCompiler;
 import com.github.maven_nar.cpptasks.msvc.MsvcMessageCompiler;
 import com.github.maven_nar.cpptasks.msvc.MsvcResourceCompiler;
+import com.github.maven_nar.cpptasks.msvc.Assembler64bitCompiler;
 import com.github.maven_nar.cpptasks.openwatcom.OpenWatcomCCompiler;
 import com.github.maven_nar.cpptasks.openwatcom.OpenWatcomFortranCompiler;
 import com.github.maven_nar.cpptasks.os390.OS390CCompiler;
@@ -225,6 +226,7 @@ public class CompilerEnum extends EnumeratedAttribute {
       new ProcessorEnumValue("msvc8", Msvc2005CCompiler.getInstance()),
       new ProcessorEnumValue("bcc", BorlandCCompiler.getInstance()),
       new ProcessorEnumValue("msrc", MsvcResourceCompiler.getInstance()),
+	  new ProcessorEnumValue("ml64", Assembler64bitCompiler.getInstance()),
       new ProcessorEnumValue("msmc", MsvcMessageCompiler.getInstance()),
       new ProcessorEnumValue("brc", BorlandResourceCompiler.getInstance()),
       new ProcessorEnumValue("df", CompaqVisualFortranCompiler.getInstance()),

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
@@ -67,7 +67,16 @@ public abstract class AbstractProcessor implements Processor, Cloneable {
 
   protected AbstractProcessor(final String[] sourceExtensions, final String[] headerExtensions) {
     this.sourceExtensions = sourceExtensions.clone();
-    this.headerExtensions = headerExtensions.clone();
+      if(headerExtensions != null)
+      {
+          this.headerExtensions = (String[]) headerExtensions.clone();
+      }
+      else
+      {
+          this.headerExtensions = null;
+      }
+
+
   }
 
   /**
@@ -87,11 +96,14 @@ public abstract class AbstractProcessor implements Processor, Cloneable {
         return DEFAULT_PROCESS_BID;
       }
     }
-    for (final String headerExtension : this.headerExtensions) {
-      if (lower.endsWith(headerExtension)) {
-        return DEFAULT_DISCARD_BID;
+      if(headerExtensions != null)
+      {
+        for (final String headerExtension : this.headerExtensions) {
+          if (lower.endsWith(headerExtension)) {
+            return DEFAULT_DISCARD_BID;
+          }
+        }
       }
-    }
     return 0;
   }
 
@@ -106,7 +118,11 @@ public abstract class AbstractProcessor implements Processor, Cloneable {
   }
 
   public String[] getHeaderExtensions() {
-    return this.headerExtensions.clone();
+      if (headerExtensions != null)
+      {
+          return (String[]) this.headerExtensions.clone();
+      }
+      return null;
   }
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
@@ -165,6 +165,11 @@ public abstract class AbstractProcessor implements Processor, Cloneable {
     final String osName = getOSName();
     return osName != null && osName.startsWith("Windows");
   }
+  
+  protected boolean isAIX() {
+        String osName = getOSName();
+        return (osName != null) && osName.equals("AIX");
+    }
 
   // ENDFREEHEP
 

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -59,7 +59,13 @@ public class GccLinker extends AbstractLdLinker {
       null);
   // FREEHEP added dllLinker for windows
   private static final GccLinker dllLinker = new GccLinker("gcc", objFiles, discardFiles, "", ".dll", false, null);
-
+  
+  //Support running on AIX
+   private static final GccLinker aLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".a", false,  null);
+  /*
+   private static final GccLinker aLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".a", false, new GccLinker("gcc", objFiles,
+            discardFiles, "lib", ".a", true, null));
+*/
   public static GccLinker getCLangInstance() {
     return clangInstance;
   }
@@ -230,7 +236,7 @@ public class GccLinker extends AbstractLdLinker {
       return isDarwin() ? machBundleLinker : isWindows() ? dllLinker : soLinker;
     }
     if (type.isSharedLibrary()) {
-      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : soLinker;
+      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : isAIX() ?  aLinker : soLinker;
     }
     // ENDFREEHEP
     return instance;

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -308,7 +308,7 @@ public class GppLinker extends AbstractLdLinker {
       return isDarwin() ? machPluginLinker : isWindows() ? dllLinker : soLinker;
     }
     if (type.isSharedLibrary()) {
-      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : soLinker;
+        return isDarwin() ? machDllLinker : isWindows() ? dllLinker :isAIX() ?  aLinker : soLinker;
     }
     // ENDFREEHEP
     return instance;

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -58,6 +58,9 @@ public class GppLinker extends AbstractLdLinker {
       false, null);
   private static final GppLinker machPluginLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib",
       ".bundle", false, null);
+	  
+  /*On AIX shared libaries use .a for extension */
+    private static final GppLinker aLinker = new GppLinker(GPP_COMMAND,objFiles, discardFiles, "lib", ".a", false, null);	  
   // FREEHEP
   private static final GppLinker machJNILinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".jnilib",
       false, null);

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/cross/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/cross/GccLinker.java
@@ -44,6 +44,10 @@ public class GccLinker extends AbstractLdLinker {
   };
   private static final GccLinker dllLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", false,
       new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", true, null));
+	  
+   /*On AIX shared libaries use .a for extension */
+    private static final GccLinker aLinker = new GccLinker("gcc",objFiles, discardFiles, "lib", ".a", false, null);
+			
   private static final GccLinker instance = new GccLinker("gcc", objFiles, discardFiles, "", "", false, null);
   private static final String[] libtoolObjFiles = new String[] {
       ".fo", ".a", ".lib", ".dll", ".so", ".sl"
@@ -232,7 +236,7 @@ public class GccLinker extends AbstractLdLinker {
       if (isDarwin()) {
         return machDllLinker;
       } else {
-        return dllLinker;
+        return isAIX() ?  aLinker: dllLinker;
       }
     }
     return instance;

--- a/src/main/java/com/github/maven_nar/cpptasks/msvc/Assembler64bitCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/msvc/Assembler64bitCompiler.java
@@ -1,0 +1,139 @@
+/*
+ * 
+ * Copyright 2002-2004 The Ant-Contrib project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.github.maven_nar.cpptasks.msvc;
+
+import com.github.maven_nar.cpptasks.CUtil;
+import com.github.maven_nar.cpptasks.OptimizationEnum;
+import com.github.maven_nar.cpptasks.compiler.CommandLineCompiler;
+import com.github.maven_nar.cpptasks.compiler.LinkType;
+import com.github.maven_nar.cpptasks.compiler.Linker;
+import com.github.maven_nar.cpptasks.compiler.Processor;
+import com.github.maven_nar.cpptasks.parser.CParser;
+import com.github.maven_nar.cpptasks.parser.Parser;
+import org.apache.tools.ant.types.Environment;
+
+import java.io.File;
+import java.util.Vector;
+
+/**
+ * Adapter for the Microsoft (R) Macro Assembler (x64)
+ * 
+ * @author Curt Arnold
+ */
+public final class Assembler64bitCompiler extends CommandLineCompiler {
+    private static final Assembler64bitCompiler instance = new Assembler64bitCompiler(
+            false, null);
+    public static Assembler64bitCompiler getInstance() {
+        return instance;
+    }
+    private String identifier;
+    private Assembler64bitCompiler(boolean newEnvironment, Environment env) {
+        super("ml64", null, new String[]{".asm"}, null, ".obj", false, null, newEnvironment, env);
+    }
+    protected void addImpliedArgs(final Vector args, 
+    		final boolean debug,
+            final boolean multithreaded, 
+			final boolean exceptions, 
+			final LinkType linkType,
+			final Boolean rtti,
+			final OptimizationEnum optimization) {
+        args.addElement("/c");
+       /* if (debug) {
+            args.addElement("/D_DEBUG");
+        } else {
+            args.addElement("/DNDEBUG");
+        }*/
+    }
+    protected void addWarningSwitch(Vector args, int level) {
+    }
+    public Processor changeEnvironment(boolean newEnvironment, Environment env) {
+        if (newEnvironment || env != null) {
+            return new Assembler64bitCompiler(newEnvironment, env);
+        }
+        return this;
+    }
+    /**
+     * The include parser for C will work just fine, but we didn't want to
+     * inherit from CommandLineCCompiler
+     */
+    protected Parser createParser(File source) {
+        return new CParser();
+    }
+    protected int getArgumentCountPerInputFile() {
+        return 2;
+    }
+    protected void getDefineSwitch(StringBuffer buffer, String define,
+            String value) {
+        MsvcProcessor.getDefineSwitch(buffer, define, value);
+    }
+    protected File[] getEnvironmentIncludePath() {
+        return CUtil.getPathFromEnvironment("INCLUDE", ";");
+    }
+    protected String getIncludeDirSwitch(String includeDir) {
+        return MsvcProcessor.getIncludeDirSwitch(includeDir);
+    }
+    protected String getInputFileArgument(File outputDir, String filename,
+            int index) {
+        if (index == 0) {
+            String outputFileName = getOutputFileNames(filename, null)[0];
+            String fullOutputName = new File(outputDir, outputFileName)
+                    .toString();
+            return "/Fo" + fullOutputName;
+        }
+        return filename;
+    }
+    public Linker getLinker(LinkType type) {
+        return MsvcLinker.getInstance().getLinker(type);
+    }
+    public int getMaximumCommandLength() {
+// FREEHEP stay on the safe side
+        return 32000; // 32767;
+    }
+    protected int getMaximumInputFilesPerCommand() {
+        return 1;
+    }
+    protected int getTotalArgumentLengthForInputFile(File outputDir,
+            String inputFile) {
+        String arg1 = getInputFileArgument(outputDir, inputFile, 0);
+        String arg2 = getInputFileArgument(outputDir, inputFile, 1);
+        return arg1.length() + arg2.length() + 2;
+    }
+    protected void getUndefineSwitch(StringBuffer buffer, String define) {
+        MsvcProcessor.getUndefineSwitch(buffer, define);
+    }
+    public String getIdentifier() {
+    	return "Microsoft (R) Macro Assembler (x64)";
+    }
+
+    /**
+     *  Empty Implementation
+     * @param baseDirPath Base directory path.
+     * @param includeDirs
+     *            Array of include directory paths
+     * @param args
+     *            Vector of command line arguments used to execute the task
+     * @param relativeArgs
+     *            Vector of command line arguments used to build the
+     * @param includePathId
+     * @param isSystem
+     */
+    protected void addIncludes(String baseDirPath, File[] includeDirs,
+                               Vector args, Vector relativeArgs, StringBuffer includePathId,
+                               boolean isSystem) {
+
+    }
+}

--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -133,9 +133,7 @@ amd64.Windows.msvc.res.excludes=
 
 amd64.Windows.msvc.idl.compiler=midl
 amd64.Windows.msvc.idl.defines=
-amd64.Windows.msvc.idl.options=
 amd64.Windows.msvc.idl.includes=**/*.idl
-amd64.Windows.msvc.idl.excludes=
 amd64.Windows.msvc.idl.options=/x64
 amd64.Windows.msvc.idl.excludes=x86/* ia64/*
 
@@ -245,38 +243,6 @@ x86.Windows.gpp.plugin.extension=dll
 x86.Windows.gpp.jni.extension=dll
 x86.Windows.gpp.executable.extension=
 
-#
-# Windows g++
-#
-
-x86.Windows.gpp.cpp.compiler=g++
-x86.Windows.gpp.cpp.defines=Windows
-x86.Windows.gpp.cpp.options=-Wall
-x86.Windows.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
-x86.Windows.gpp.cpp.excludes=
-
-x86.Windows.gpp.c.compiler=gcc
-x86.Windows.gpp.c.defines=Windows
-x86.Windows.gpp.c.options=-Wall
-x86.Windows.gpp.c.includes=**/*.c
-x86.Windows.gpp.c.excludes=
-
-x86.Windows.gpp.fortran.compiler=gfortran
-x86.Windows.gpp.fortran.defines=Windows
-x86.Windows.gpp.fortran.options=-Wall
-x86.Windows.gpp.fortran.includes=**/*.f **/*.for **/*.f90
-x86.Windows.gpp.fortran.excludes=
-
-x86.Windows.gpp.java.include=include;include/win32
-x86.Windows.gpp.java.runtimeDirectory=lib
-
-x86.Windows.gpp.lib.prefix=lib
-x86.Windows.gpp.shared.prefix=
-x86.Windows.gpp.static.extension=a
-x86.Windows.gpp.shared.extension=dll
-x86.Windows.gpp.plugin.extension=dll
-x86.Windows.gpp.jni.extension=dll
-x86.Windows.gpp.executable.extension=
 
 
 # FIXME to be removed when NAR-6
@@ -1072,3 +1038,70 @@ ppc.AIX.xlC.static.extension=a
 ppc.AIX.xlC.shared.extension=a
 ppc.AIX.xlC.plugin.extension=a
 ppc.AIX.xlC.jni.extension=a
+
+# AIX ("AIX" => AIX) PowerPC
+#
+ppc64.AIX.linker=g++
+
+ppc64.AIX.gpp.cpp.compiler=g++
+ppc64.AIX.gpp.cpp.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
+ppc64.AIX.gpp.cpp.excludes=
+
+ppc64.AIX.gpp.c.compiler=gcc
+ppc64.AIX.gpp.c.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gpp.c.includes=**/*.c **/*.m
+ppc64.AIX.gpp.c.excludes=
+
+ppc64.AIX.gpp.fortran.compiler=gfortran
+ppc64.AIX.gpp.fortran.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.fortran.options=-Wall -fno-automatic -fno-second-underscore
+ppc64.AIX.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+ppc64.AIX.gpp.fortran.excludes=
+
+ppc64.AIX.gpp.java.include=include
+ppc64.AIX.gpp.java.runtimeDirectory=IGNORED
+
+ppc64.AIX.gpp.lib.prefix=lib
+ppc64.AIX.gpp.shared.prefix=lib
+ppc64.AIX.gpp.static.extension=a
+ppc64.AIX.gpp.shared.extension=a
+ppc64.AIX.gpp.plugin.extension=a
+ppc64.AIX.gpp.jni.extension=a
+ppc64.AIX.gpp.executable.extension=
+
+#
+# AIX ("AIX" => AIX) PowerPC      GCC linker
+#
+
+ppc64.AIX.gcc.cpp.compiler=g++
+ppc64.AIX.gcc.cpp.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.cpp.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gcc.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
+ppc64.AIX.gcc.cpp.excludes=
+
+ppc64.AIX.gcc.c.compiler=gcc
+ppc64.AIX.gcc.c.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.c.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gcc.c.includes=**/*.c **/*.m
+ppc64.AIX.gcc.c.excludes=
+
+ppc64.AIX.gcc.fortran.compiler=gfortran
+ppc64.AIX.gcc.fortran.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.fortran.options=-Wall -fno-automatic -fno-second-underscore
+ppc64.AIX.gcc.fortran.includes=**/*.f **/*.for **/*.f90
+ppc64.AIX.gcc.fortran.excludes=
+
+ppc64.AIX.gcc.java.include=include
+ppc64.AIX.gcc.java.runtimeDirectory=IGNORED
+
+ppc64.AIX.gcc.lib.prefix=lib
+ppc64.AIX.gcc.shared.prefix=lib
+ppc64.AIX.gcc.static.extension=a
+ppc64.AIX.gcc.shared.extension=a
+ppc64.AIX.gcc.plugin.extension=a
+ppc64.AIX.gcc.jni.extension=a
+ppc64.AIX.gcc.executable.extension=
+#

--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -98,6 +98,12 @@ amd64.Windows.msvc.c.options=
 amd64.Windows.msvc.c.includes=**/*.c
 amd64.Windows.msvc.c.excludes=
 
+amd64.Windows.msvc.asm.compiler=ml64
+amd64.Windows.msvc.asm.defines=
+amd64.Windows.msvc.asm.options=
+amd64.Windows.msvc.asm.includes=**/*.asm
+amd64.Windows.msvc.asm.excludes=
+
 amd64.Windows.msvc.fortran.compiler=df
 amd64.Windows.msvc.fortran.defines=WIN32
 amd64.Windows.msvc.fortran.options=


### PR DESCRIPTION
On AIX the objects needs to be created with ".a" extension, not ".so" like on Linux/Solaris. Also- needs to had support in the NAR it self to the configuration of AIX