### PR TITLE
Improve implementation of executing command

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
@@ -400,7 +400,8 @@ public class CUtil {
       final boolean newEnvironment, final Environment env) throws BuildException {
     try {
       task.log(Commandline.toString(cmdline), task.getCommandLogLevel());
-      final Execute exe = new Execute(new LogStreamHandler(task, Project.MSG_INFO, Project.MSG_ERR));
+
+     /* final Execute exe = new Execute(new LogStreamHandler(task, Project.MSG_INFO, Project.MSG_ERR));
       if (System.getProperty("os.name").equals("OS/390")) {
         exe.setVMLauncher(false);
       }
@@ -418,6 +419,8 @@ public class CUtil {
       }
       exe.setNewenvironment(newEnvironment);
       return exe.execute();
+            */
+	  return CommandExecution.runCommand(cmdline,workingDir,task);
     } catch (final java.io.IOException exc) {
       throw new BuildException("Could not launch " + cmdline[0] + ": " + exc, task.getLocation());
     }

--- a/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
@@ -1,0 +1,93 @@
+package com.github.maven_nar.cpptasks;
+
+
+import org.apache.tools.ant.Project;
+
+import java.io.*;
+
+
+class StreamGobbler extends Thread {
+    InputStream is;
+    String type;
+    CCTask task;
+
+
+    StreamGobbler(InputStream is, String type, CCTask task) {
+        this.is = is;
+        this.type = type;
+        this.task = task;
+    }
+
+
+    public void run() {
+        try {
+            InputStreamReader isr = new InputStreamReader(is);
+            BufferedReader br = new BufferedReader(isr);
+            String line;
+            while ((line = br.readLine()) != null)
+                task.log(type +">"+ line );
+
+        } catch (IOException ioe) {
+            ioe.printStackTrace();
+        }
+
+
+    }
+}
+
+
+public class CommandExecution {
+
+
+
+
+    public static int runCommand(String[] cmdArgs, File workDir, CCTask task) throws  IOException{
+
+
+        try {
+
+            //Create ProcessBuilder with the command arguments
+            ProcessBuilder pb = new ProcessBuilder(cmdArgs);
+
+            //Redirect the stderr to the stdout
+            pb.redirectErrorStream(true);
+
+            pb.directory(workDir);
+
+            //Start the new process
+            Process process = pb.start();
+
+
+            // Adding to log the command
+            StringBuilder builder = new StringBuilder();
+            for(String s : cmdArgs) {
+
+                builder.append(s);
+                //Append space
+                builder.append(" ");
+            }
+            task.log("Executing - " + builder.toString(), Project.MSG_INFO);
+
+
+            //Create the StreamGobbler to read the process output
+            StreamGobbler outputGobbler = new StreamGobbler(process.getInputStream(), "OUTPUT",task);
+
+            outputGobbler.start();
+
+            int exit_value;
+
+            //Wait for the process to finish
+            exit_value = process.waitFor();
+
+
+            return exit_value;
+
+        } catch (InterruptedException e) {
+
+            e.printStackTrace();
+            return -2;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Instead of using the "Execute" class of ANT, I am now using the standard Java execution process using ProcessBuilder.  Also- the executed command is printed so it is easy to see what might fail