### PR TITLE
Upgrade version of Maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>2.3.2</version>
+          <version>3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-site-plugin</artifactId>


### PR DESCRIPTION
The old version of compiler plugin does not support well JDK 1.7, so I upgraded it to 3.1 that support.