### PR TITLE
Add support for g++ on AIX

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -65,7 +65,7 @@ public abstract class AbstractNarMojo extends AbstractMojo implements NarConstan
 
   /**
    * The Operating System for the nar. Some choices are: "Windows", "Linux",
-   * "MacOSX", "SunOS", ... Defaults to a
+   * "MacOSX", "SunOS","AIX" ... Defaults to a
    * derived value from ${os.name} FIXME table missing
    */
   @Parameter(property = "nar.os")

--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -364,6 +364,14 @@ public final class NarUtil {
       if (name.equals("mac os x")) {
         os = OS.MACOSX;
       }
+	 if ( name.equals( "AIX" ) )
+	{
+		os = OS.AIX;
+	}
+	if ( name.equals( "SunOS" ) )
+	{
+		os = OS.SUNOS;
+	}
     }
     return os;
   }

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/AbstractProcessor.java
@@ -149,7 +149,12 @@ public abstract class AbstractProcessor implements Processor, Cloneable {
     final String osName = getOSName();
     return osName != null && osName.startsWith("Windows");
   }
-
+ 
+  protected boolean isAIX() {
+       final String osName = getOSName();
+        return (osName != null) && osName.equals("AIX");
+   }
+	
   // ENDFREEHEP
 
   @Override

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -60,6 +60,9 @@ public class GccLinker extends AbstractLdLinker {
   // FREEHEP added dllLinker for windows
   private static final GccLinker dllLinker = new GccLinker("gcc", objFiles, discardFiles, "", ".dll", false, null);
 
+   //Support running on AIX
+  private static final GccLinker aLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".a", false,  null);
+  
   public static GccLinker getCLangInstance() {
     return clangInstance;
   }
@@ -230,7 +233,7 @@ public class GccLinker extends AbstractLdLinker {
       return isDarwin() ? machBundleLinker : isWindows() ? dllLinker : soLinker;
     }
     if (type.isSharedLibrary()) {
-      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : soLinker;
+      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : isAIX() ?  aLinker : soLinker;
     }
     // ENDFREEHEP
     return instance;

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -58,6 +58,8 @@ public class GppLinker extends AbstractLdLinker {
       false, null);
   private static final GppLinker machPluginLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib",
       ".bundle", false, null);
+  /*On AIX shared libaries use .a for extension */
+    private static final GppLinker aLinker = new GppLinker(GPP_COMMAND,objFiles, discardFiles, "lib", ".a", false, null);
   // FREEHEP
   private static final GppLinker machJNILinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".jnilib",
       false, null);
@@ -305,7 +307,7 @@ public class GppLinker extends AbstractLdLinker {
       return isDarwin() ? machPluginLinker : isWindows() ? dllLinker : soLinker;
     }
     if (type.isSharedLibrary()) {
-      return isDarwin() ? machDllLinker : isWindows() ? dllLinker : soLinker;
+      return isDarwin() ? machDllLinker : isWindows() ? dllLinker :isAIX() ?  aLinker : soLinker;
     }
     // ENDFREEHEP
     return instance;

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/cross/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/cross/GccLinker.java
@@ -44,6 +44,9 @@ public class GccLinker extends AbstractLdLinker {
   };
   private static final GccLinker dllLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", false,
       new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", true, null));
+   /*On AIX shared libaries use .a for extension */
+  private static final GccLinker aLinker = new GccLinker("gcc",objFiles, discardFiles, "lib", ".a", false, null);
+	  
   private static final GccLinker instance = new GccLinker("gcc", objFiles, discardFiles, "", "", false, null);
   private static final String[] libtoolObjFiles = new String[] {
       ".fo", ".a", ".lib", ".dll", ".so", ".sl"
@@ -232,7 +235,7 @@ public class GccLinker extends AbstractLdLinker {
       if (isDarwin()) {
         return machDllLinker;
       } else {
-        return dllLinker;
+        return isAIX() ?  aLinker:dllLinker;
       }
     }
     return instance;

--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -1066,3 +1066,70 @@ ppc.AIX.xlC.static.extension=a
 ppc.AIX.xlC.shared.extension=a
 ppc.AIX.xlC.plugin.extension=a
 ppc.AIX.xlC.jni.extension=a
+
+# AIX ("AIX" => AIX) PowerPC
+#
+ppc64.AIX.linker=g++
+
+ppc64.AIX.gpp.cpp.compiler=g++
+ppc64.AIX.gpp.cpp.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
+ppc64.AIX.gpp.cpp.excludes=
+
+ppc64.AIX.gpp.c.compiler=gcc
+ppc64.AIX.gpp.c.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gpp.c.includes=**/*.c **/*.m
+ppc64.AIX.gpp.c.excludes=
+
+ppc64.AIX.gpp.fortran.compiler=gfortran
+ppc64.AIX.gpp.fortran.defines=Darwin GNU_GCC
+ppc64.AIX.gpp.fortran.options=-Wall -fno-automatic -fno-second-underscore
+ppc64.AIX.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+ppc64.AIX.gpp.fortran.excludes=
+
+ppc64.AIX.gpp.java.include=include
+ppc64.AIX.gpp.java.runtimeDirectory=IGNORED
+
+ppc64.AIX.gpp.lib.prefix=lib
+ppc64.AIX.gpp.shared.prefix=lib
+ppc64.AIX.gpp.static.extension=a
+ppc64.AIX.gpp.shared.extension=a
+ppc64.AIX.gpp.plugin.extension=a
+ppc64.AIX.gpp.jni.extension=a
+ppc64.AIX.gpp.executable.extension=
+
+#
+# AIX ("AIX" => AIX) PowerPC      GCC linker
+#
+
+ppc64.AIX.gcc.cpp.compiler=g++
+ppc64.AIX.gcc.cpp.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.cpp.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gcc.cpp.includes=**/*.cc **/*.cpp **/*.cxx **/*.mm
+ppc64.AIX.gcc.cpp.excludes=
+
+ppc64.AIX.gcc.c.compiler=gcc
+ppc64.AIX.gcc.c.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.c.options=-Wall -Wno-long-long -Wpointer-arith
+ppc64.AIX.gcc.c.includes=**/*.c **/*.m
+ppc64.AIX.gcc.c.excludes=
+
+ppc64.AIX.gcc.fortran.compiler=gfortran
+ppc64.AIX.gcc.fortran.defines=Darwin GNU_GCC
+ppc64.AIX.gcc.fortran.options=-Wall -fno-automatic -fno-second-underscore
+ppc64.AIX.gcc.fortran.includes=**/*.f **/*.for **/*.f90
+ppc64.AIX.gcc.fortran.excludes=
+
+ppc64.AIX.gcc.java.include=include
+ppc64.AIX.gcc.java.runtimeDirectory=IGNORED
+
+ppc64.AIX.gcc.lib.prefix=lib
+ppc64.AIX.gcc.shared.prefix=lib
+ppc64.AIX.gcc.static.extension=a
+ppc64.AIX.gcc.shared.extension=a
+ppc64.AIX.gcc.plugin.extension=a
+ppc64.AIX.gcc.jni.extension=a
+ppc64.AIX.gcc.executable.extension=
+#


### PR DESCRIPTION
n AIX the objects needs to be created with ".a" extension, not ".so" like on Linux/Solaris. Also- needs to had support in the NAR it self to the configuration of AIX