### PR TITLE
Add support for HPE Fortify code scanning during compilation

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -121,6 +121,16 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
   @Parameter
   private Java java;
 
+    /*
+  * To support scanning the code with HPE Fortify
+  * The attribute is used both as a flag that Fortify is required and the value set is used for the
+  * When setting a value -  sourceanalyzer –b <fortifyID> will be prepended to the
+  * command line
+  * */
+  @Parameter(defaultValue = "")
+  private String fortifyID;
+
+  
   /**
    * Flag to cpptasks to indicate whether linker options should be decorated or
    * not
@@ -227,6 +237,11 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
   public void setCpp(final Cpp cpp) {
     this.cpp = cpp;
     cpp.setAbstractCompileMojo(this);
+  }
+  
+  protected final String getfortifyID()
+  {
+    return this.fortifyID;
   }
 
   public final void setDependencyLibOrder(final List/* <String> */order) {

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -179,6 +179,8 @@ public class NarCompileMojo extends AbstractCompileMojo {
     if (getCpp() != null) {
       final CompilerDef cpp = getCpp().getCompiler(Compiler.MAIN, null);
       if (cpp != null) {
+		// Set FortifyID attribute
+		cpp.setFortifyID(getfortifyID());
         task.addConfiguredCompiler(cpp);
       }
     }
@@ -187,6 +189,8 @@ public class NarCompileMojo extends AbstractCompileMojo {
     if (getC() != null) {
       final CompilerDef c = getC().getCompiler(Compiler.MAIN, null);
       if (c != null) {
+		// Set FortifyID attribute
+		c.setFortifyID(getfortifyID());  
         task.addConfiguredCompiler(c);
       }
     }

--- a/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CompilerDef.java
@@ -62,6 +62,7 @@ public final class CompilerDef extends ProcessorDef {
   private String compilerPrefix;
   private File workDir;
   private boolean gccFileAbsolutePath;
+  private String fortifyID="";
 
   private boolean clearDefaultOptions;
 
@@ -571,7 +572,14 @@ public final class CompilerDef extends ProcessorDef {
   public void setWorkDir(final File workDir) {
       this.workDir = workDir;
   }
-  
+
+  public void setFortifyID(final String fortifyID) {
+    this.fortifyID = fortifyID;
+  }
+
+  public String getFortifyID() {
+    return this.fortifyID;
+  }
   /**
    * Enumerated attribute with the values "none", "severe", "default",
    * "production", "diagnostic", and "aserror".

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -60,6 +60,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
   private final boolean libtool;
   private final CommandLineCompiler libtoolCompiler;
   private final boolean newEnvironment;
+  private String fortifyID="";
 
   protected CommandLineCompiler(final String command, final String identifierArg, final String[] sourceExtensions,
       final String[] headerExtensions,
@@ -214,6 +215,13 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
       ArrayList<String> commandlinePrefix = new ArrayList<>();
       if (this.libtool) {
         commandlinePrefix.add("libtool");
+      }
+      if((this.fortifyID !=null) && (!this.fortifyID.equals("")))
+      {// If FortifyID attribute was set, run the Fortify framework
+
+        commandlinePrefix.add("sourceanalyzer");
+        commandlinePrefix.add("-b");
+        commandlinePrefix.add(this.fortifyID);
       }
       commandlinePrefix.add(command);
       Collections.addAll(commandlinePrefix, args);
@@ -404,6 +412,7 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     final String path = specificDef.getToolPath();
 
     CommandLineCompiler compiler = this;
+
     Environment environment = specificDef.getEnv();
     if (environment == null) {
       for (final ProcessorDef baseDef : baseDefs) {
@@ -415,6 +424,9 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
     } else {
       compiler = (CommandLineCompiler) compiler.changeEnvironment(specificDef.isNewEnvironment(), environment);
     }
+    // Pass the fortifyID for compiler
+    compiler.fortifyID = specificDef.getFortifyID();
+
     return new CommandLineCompilerConfiguration(compiler, configId, incPath, sysIncPath, envIncludePath,
         includePathIdentifier.toString(), argArray, paramArray, rebuild, endArgs, path, specificDef.getCcache());
   }


### PR DESCRIPTION
We need to use HPE Fortify to scan the C/C++ code, this scanning is done during compilation by adding prefix - sourceanalyzer -b <FortifyID string>

The way I implemented it was to use the new attribute existence as a flag that we need to use the Fortify prefix