### PR TITLE
Support working with non default linkers

### DIFF
--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -248,9 +248,25 @@ public final class NarUtil {
 
   public static AOL getAOL(final MavenProject project, final String architecture, final String os, final Linker linker,
       final String aol, final Log log) throws MojoFailureException, MojoExecutionException {
-    // adjust aol
-    return aol == null ? new AOL(getArchitecture(architecture), getOS(os), getLinkerName(project, architecture, os,
-        linker, log)) : new AOL(aol);
+
+    /*
+    To support a linker that is not the default linker specified in the aol.properties
+    * */
+    String aol_linker;
+
+    if(linker != null & linker.getName() != null)
+    {
+      log.debug("linker original name: " + linker.getName());
+      aol_linker = linker.getName();
+    }
+    else
+    {
+      log.debug("linker original name not exist ");
+      aol_linker = getLinkerName(project, architecture, os,linker, log);
+    }
+    log.debug("aol_linker: " + aol_linker);
+
+    return aol == null ? new AOL(getArchitecture(architecture), getOS(os), aol_linker) : new AOL(aol);
   }
 
   public static String getAOLKey(final String aol) {


### PR DESCRIPTION
Currently when the aol.properties contains a definition of linker for specific OS+ARCH (For example- ppc64.AIX.linker=g++) , NAR is by default trying to use that linker and ignore the linker that is configured (If there is a different configuration).

The fix is to first check if a linker was defined, and only if not- choose the default configuration