### PR TITLE
Adding support for forcing direct dependencies

### DIFF
--- a/src/it/it0032-directDepsOnly-fail/invoker.properties
+++ b/src/it/it0032-directDepsOnly-fail/invoker.properties
@@ -1,0 +1,2 @@
+# The expected result of the build for this project we WANT the project to fail.
+invoker.buildResult = failure

--- a/src/it/it0032-directDepsOnly-fail/pom.xml
+++ b/src/it/it0032-directDepsOnly-fail/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0032-directDepsOnly-fail</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Executable and Static Libraries</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Executable depending on static libraries.
+  </description>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+            <clearDefaultOptions>true</clearDefaultOptions>
+          </linker>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <run>true</run>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0031-push-deps-to-lowest-order-C</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0032-directDepsOnly-fail/src/main/c++/A.cpp
+++ b/src/it/it0032-directDepsOnly-fail/src/main/c++/A.cpp
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "B1.h"
+#include "B2.h"
+#include "C1.h"
+#include "C2.h"
+
+int main(int argc, char *argv[]) {
+   B1 b1;
+   B2 b2;
+   C1 c1;
+   C2 c2;
+
+   printf ("%s\n", b1.print ());
+   printf ("%s\n", b2.print ());
+   printf ("%s\n", c1.print ());
+   printf ("%s\n", c2.print ());
+
+   return 0;
+}

--- a/src/it/it0032-directDepsOnly-no-deps/echo.bat
+++ b/src/it/it0032-directDepsOnly-no-deps/echo.bat
@@ -1,0 +1,4 @@
+@echo off
+rem dummy batch file to test user defined commands from
+rem nar-process-libraries. Just display the arguments passed
+echo %*

--- a/src/it/it0032-directDepsOnly-no-deps/pom.xml
+++ b/src/it/it0032-directDepsOnly-no-deps/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0032-directDepsOnly-no-deps</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Static Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Simple static library and test file; test nar-process-libraries commands
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+    <command.executable>echo</command.executable>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+          <tests>
+            <test>
+              <name>HelloWorldTest</name>
+              <link>static</link>
+            </test>
+          </tests>
+        </configuration>
+        <executions>
+          <execution>
+              <id>run-commands</id>
+              <goals>
+                  <goal>nar-process-libraries</goal>
+              </goals>
+              <configuration>
+                  <commands>
+                      <!-- run command with arguments -->
+                      <processLibraryCommand>
+                          <executable>${command.executable}</executable>
+                          <arguments>
+                              <argument>Hello from ${nar.aol}!</argument>
+                          </arguments>
+                          <type>static</type>
+                      </processLibraryCommand>
+                      <!-- run command without arguments -->
+                      <processLibraryCommand>
+                          <executable>${command.executable}</executable>
+                          <type>static</type>
+                      </processLibraryCommand>
+                  </commands>
+              </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <!-- Setup correct command executable to run based on OS -->
+  <profiles>
+    <profile>
+      <id>windows</id>
+      <activation>
+        <os>
+          <family>windows</family>
+        </os>
+      </activation>
+      <properties>
+        <command.executable>echo.bat</command.executable>
+      </properties>
+    </profile>
+  </profiles>
+
+</project>

--- a/src/it/it0032-directDepsOnly-no-deps/src/main/c/HelloWorldLib.c
+++ b/src/it/it0032-directDepsOnly-no-deps/src/main/c/HelloWorldLib.c
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+char* HelloWorldLib_sayHello() {
+	return "Hello NAR LIB World!";
+}
+

--- a/src/it/it0032-directDepsOnly-no-deps/src/main/include/HelloWorldLib.h
+++ b/src/it/it0032-directDepsOnly-no-deps/src/main/include/HelloWorldLib.h
@@ -1,0 +1,25 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef HelloWorldLib_H
+#define HelloWorldLib_H
+
+extern char* HelloWorldLib_sayHello();
+
+#endif

--- a/src/it/it0032-directDepsOnly-no-deps/src/test/c/HelloWorldTest.c
+++ b/src/it/it0032-directDepsOnly-no-deps/src/test/c/HelloWorldTest.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+int main(int argc, char *argv[]) {
+	printf("%s\n", HelloWorldLib_sayHello());
+	return 0;
+}
+
+

--- a/src/it/it0032-directDepsOnly-success/pom.xml
+++ b/src/it/it0032-directDepsOnly-success/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0032-directDepsOnly-success</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Executable and Static Libraries</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Executable depending on static libraries.
+  </description>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+            <clearDefaultOptions>true</clearDefaultOptions>
+          </linker>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <run>true</run>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0031-push-deps-to-lowest-order-B</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0031-push-deps-to-lowest-order-C</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0032-directDepsOnly-success/src/main/c++/A.cpp
+++ b/src/it/it0032-directDepsOnly-success/src/main/c++/A.cpp
@@ -1,0 +1,38 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "B1.h"
+#include "B2.h"
+#include "C1.h"
+#include "C2.h"
+
+int main(int argc, char *argv[]) {
+   B1 b1;
+   B2 b2;
+   C1 c1;
+   C2 c2;
+
+   printf ("%s\n", b1.print ());
+   printf ("%s\n", b2.print ());
+   printf ("%s\n", c1.print ());
+   printf ("%s\n", c2.print ());
+
+   return 0;
+}

--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -110,6 +110,14 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
   private boolean libtool;
 
   /**
+   * Forces project to specify all it's dependencies and not inherit transitive  
+   * dependencies.
+   @since 3.5.3
+   */
+  @Parameter(defaultValue = "false")
+  protected boolean directDepsOnly;
+
+  /**
    * List of tests to create
    */
   @Parameter
@@ -200,6 +208,15 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
 
   protected final int getMaxCores(final AOL aol) throws MojoExecutionException {
     return getNarInfo().getProperty(aol, "maxCores", this.maxCores);
+  }
+
+  /**
+   * Get value of the directDepsOnly flag.
+   * @return {@code true} if directDepsOnly is true, {@code false} otherwise.
+   * @since 3.5.3
+   */
+  protected boolean getDirectDepsOnly(){
+     return this.directDepsOnly;
   }
 
   protected final Message getMessage() {

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -232,22 +232,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
           throw e;
       }
 
-      if (specifyDirectDeps)
-      {
-        // Get first level of deps, when specifyAllDirectDeps is true those can be the only ones linked.
-        Set<String> directDepsSet = getDirectDepsSet(verboseTreeRootNode);
-
-        // Trim all deps from verboseDepList that are not in the directDepsSet, warn if they are found.
-        ListIterator <String> it = verboseDepList.listIterator();
-        while(it.hasNext()){
-            String dep = it.next();
-            if(!directDepsSet.contains(dep)){
-                this.getLog().warn("Stray dependency: " + dep + " found. This may cause build failures.");
-                verboseDepList.remove(it);
-            }
-        }
-      }
-
       // Create set that tracks if we found a duplicate library in the list
       Set<String> reducedDepSet = new HashSet <String> ();
       
@@ -272,7 +256,24 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
             depLevelOrderStr= depStr;
           }
         }
-      } 
+      }
+
+      if (specifyDirectDeps)
+      {
+        // Get first level of deps, when specifyAllDirectDeps is true those can be the only ones linked.
+        Set<String> directDepsSet = getDirectDepsSet(verboseTreeRootNode);
+
+        // Trim all deps from verboseDepList that are not in the directDepsSet, warn if they are found.
+        Iterator <String> it = reducedDepSet.iterator();
+        while(it.hasNext()){
+            String dep = it.next();
+            if(!directDepsSet.contains(dep)){
+                this.getLog().warn("Stray dependency: " + dep + " found. This may cause build failures.");
+                reducedDepSet.remove(it);
+            }
+        }
+      }
+
     }
     else
     {

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -201,7 +201,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    * @return {@link String Dependency tree string} of comma separated list of groupId:artifactId
    * @throws MojoExecutionException
    */
-  protected String dependencyTreeOrderStr(boolean pushDepsToLowestOrder) throws MojoExecutionException
+  protected String dependencyTreeOrderStr(boolean pushDepsToLowestOrder, boolean specifyDirectDeps) throws MojoExecutionException
   {
     String depLevelOrderStr = "";
     DependencyNode libTreeRootNode;
@@ -220,32 +220,49 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
      * link order. We will use the full dependency tree from Aether (unmediated)
      * to determine this order. 
      */
-    if (pushDepsToLowestOrder)
+    if (pushDepsToLowestOrder || specifyDirectDeps)
     {
-      List <String> VerboseDepList;
+      org.eclipse.aether.graph.DependencyNode verboseTreeRootNode = getVerboseDependencyTree ();
+      List <String> verboseDepList;
       try {
-        // Get verbose (full) list of dependencies
-        VerboseDepList = depLevelVerboseList(getVerboseDependencyTree ());
+          // Get verbose (full) list of dependencies
+          verboseDepList = depLevelVerboseList(verboseTreeRootNode);
       } catch (MojoExecutionException e) {
-        this.getLog().warn("Exception caught while getting verbose dependency list: ", e);
-        throw e;
+          this.getLog().warn("Exception caught while getting verbose dependency list: ", e);
+          throw e;
       }
-      
+
+      if (specifyDirectDeps)
+      {
+        // Get first level of deps, when specifyAllDirectDeps is true those can be the only ones linked.
+        Set<String> directDepsSet = getDirectDepsSet(verboseTreeRootNode);
+
+        // Trim all deps from verboseDepList that are not in the directDepsSet, warn if they are found.
+        ListIterator <String> it = verboseDepList.listIterator();
+        while(it.hasNext()){
+            String dep = it.next();
+            if(!directDepsSet.contains(dep)){
+                this.getLog().warn("Stray dependency: " + dep + " found. This may cause build failures.");
+                verboseDepList.remove(it);
+            }
+        }
+      }
+
       // Create set that tracks if we found a duplicate library in the list
-      Set<String> ReducedDepSet = new HashSet <String> ();
+      Set<String> reducedDepSet = new HashSet <String> ();
       
       /* Traverse full dependency list in REVERSE order. The dependencies at the
        * end of the list signify the ones that are most heavily depended on 
        * and therefore need to occur later in the link order.
        */
-      for (int i = VerboseDepList.size()-1; i >= 0; i--)
+      for (int i = verboseDepList.size()-1; i >= 0; i--)
       {
-        String depStr = VerboseDepList.get(i);
+        String depStr = verboseDepList.get(i);
 
         /* Create link order by pushing new dep to the front of the list. Do not
          * insert dep if it was added already (i.e. if adding to ReducedDepSet fails)
          */
-        if (ReducedDepSet.add(depStr))
+        if (reducedDepSet.add(depStr))
         {
           this.getLog().debug(depStr);
 
@@ -284,6 +301,27 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     return depLevelOrderStr;
   }
 
+  /**
+   * Gets the set strings of the form "&lt;groupId&gt;:&lt;artifactId&gt;" representing the specified nodes direct dependencies (immediate children).
+   *
+   * @param rootNode {@link org.eclipse.aether.graph.DependencyNode root node} of the tree to fetch the direct dependencies from.
+   * @return {@link HashSet<String>} of the form "&lt;groupId&gt;:&lt;artifactId&gt;" containing all direct dependencies of the parameter specified by rootNode.
+   * @since 3.5.3
+   */
+  protected HashSet<String> getDirectDepsSet(org.eclipse.aether.graph.DependencyNode rootNode)
+  {
+    HashSet<String> directDepsSet = new HashSet<String> ();
+    List <org.eclipse.aether.graph.DependencyNode> directDepsList = rootNode.getChildren();
+    ListIterator <org.eclipse.aether.graph.DependencyNode> iter = directDepsList.listIterator();
+
+    // Accumulate set that represents the collection of direct deps
+    while(iter.hasNext()){
+      org.eclipse.aether.artifact.Artifact art = iter.next().getArtifact();
+      directDepsSet.add(createArtifactString(art));
+    }
+
+    return directDepsSet;
+  }
   
   /**
    * Get List of Nodes of Dependency tree serialised by traversing nodes
@@ -348,7 +386,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
 
     // Iterate over each breadth to aggregate the dependency list
     while (!NodeChildList.isEmpty()) {
-        NodeChildList = levelTraverseVerboseTreeList(NodeChildList, AggDepNodeList, rootNode);
+      NodeChildList = levelTraverseVerboseTreeList(NodeChildList, AggDepNodeList, rootNode);
     }
     
     List <String> FullDepList = new ArrayList<String> ();
@@ -356,8 +394,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     // Construct list of Strings representing the deps in the form "<groupId>:<artifactId>"
     for (ListIterator<org.eclipse.aether.graph.DependencyNode> it = AggDepNodeList.listIterator (); it.hasNext ();)
     {
-      org.eclipse.aether.artifact.Artifact art = it.next ().getArtifact();
-      FullDepList.add(art.getGroupId() + ":" + art.getArtifactId());
+      FullDepList.add(createArtifactString(it.next().getArtifact()));
     }
     return FullDepList;
   }
@@ -397,6 +434,18 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
   }
 
   /**
+   * Convenience function for constructing a String representing an artifact in the form "<groupId>:<artifactId>"
+   * 
+   * @param artifact {@link org.eclipse.aether.Artifact artifact} to construct string from
+   * @return {@link String} in the form <groupId>:<artifactId" representing the artifact
+   * @since 3.5.3
+   */
+  private String createArtifactString (org.eclipse.aether.artifact.Artifact artifact)
+  {
+    return new String(artifact.getGroupId() + ":" + artifact.getArtifactId());
+  }
+
+  /**
    * Convenience function for determining if the 2 specified dependency
    * nodes' artifacts match (i.e. if their group and artifact ids match)
    * 
@@ -425,7 +474,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    * @return root node of the project Dependency tree
    * @throws MojoExecutionException
    */
-  private DependencyNode getRootNodeDependecyTree() throws MojoExecutionException{
+  protected DependencyNode getRootNodeDependecyTree() throws MojoExecutionException{
     try {
       ArtifactFilter artifactFilter = null;
 

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -387,9 +387,11 @@ public class Linker {
 
     //if No user preference of dependency library link order is specified then use the Default one nar generate.
     if ((this.narDependencyLibOrder == null) && (narDefaultDependencyLibOrder)) {
-        this.narDependencyLibOrder = mojo.dependencyTreeOrderStr(pushDepsToLowestOrder);
+        this.narDependencyLibOrder = mojo.dependencyTreeOrderStr(pushDepsToLowestOrder, mojo.getDirectDepsOnly());
     } else if (pushDepsToLowestOrder && !narDefaultDependencyLibOrder) {
         this.log.warn("pushDepsToLowestOrder will have no effect since narDefaultDependencyLibOrder is disabled");
+    } else if (mojo.getDirectDepsOnly() && !narDefaultDependencyLibOrder) {
+        this.log.warn("directDepsOnly will have no effect since narDefaultDependencyLibOrder is disabled");
     }
 
     // record the preference for nar dependency library link order

--- a/src/main/java/com/github/maven_nar/NarInfo.java
+++ b/src/main/java/com/github/maven_nar/NarInfo.java
@@ -162,6 +162,24 @@ public class NarInfo {
     return getProperty(aol, "syslibs.names");
   }
 
+  /**
+   * Get the Group Id of the NarInfo instance
+   * @return {@link String} representing a NarInfo object's Group Id.
+   * @since 3.5.3
+   */
+  public String getGroupId() {
+      return this.groupId;
+  }
+
+  /**
+   * Get the Artifact Id of the NarInfo instance
+   * @return {@link String} representing a NarInfo object's Artifact Id.
+   * @since 3.5.3
+   */
+  public String getArtifactId() {
+      return this.artifactId;
+  }
+
   public final void read(final JarFile jar) throws IOException {
     this.info.load(jar.getInputStream(getNarPropertiesEntry(jar)));
   }


### PR DESCRIPTION
The changes here fix issue 280:
Enhancement - The nar plugin should provide an option to restrict dependencies to direct dependencies only #280

Included is a set of automated tests that verify the new enhancement. Any and all feedback is welcome. Thanks folks!