### PR TITLE
Transitive deps

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -325,7 +325,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
   }
   
   /**
-   * Get List of Nodes of Dependency tree serialised by traversing nodes
+   * Get List of Nodes of Dependency tree serialized by traversing nodes
    * in Level-Order way (also called BFS algorithm)
    *
    * @param rootNode root node of the project Dependency tree

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -389,9 +389,9 @@ public class Linker {
     if ((this.narDependencyLibOrder == null) && (narDefaultDependencyLibOrder)) {
         this.narDependencyLibOrder = mojo.dependencyTreeOrderStr(pushDepsToLowestOrder, mojo.getDirectDepsOnly());
     } else if (pushDepsToLowestOrder && !narDefaultDependencyLibOrder) {
-        this.log.warn("pushDepsToLowestOrder will have no effect since narDefaultDependencyLibOrder is disabled");
+        mojo.getLog().warn("pushDepsToLowestOrder will have no effect since narDefaultDependencyLibOrder is disabled");
     } else if (mojo.getDirectDepsOnly() && !narDefaultDependencyLibOrder) {
-        this.log.warn("directDepsOnly will have no effect since narDefaultDependencyLibOrder is disabled");
+        mojo.getLog().warn("directDepsOnly will have no effect since narDefaultDependencyLibOrder is disabled");
     }
 
     // record the preference for nar dependency library link order

--- a/src/main/java/com/github/maven_nar/NarInfo.java
+++ b/src/main/java/com/github/maven_nar/NarInfo.java
@@ -180,6 +180,15 @@ public class NarInfo {
       return this.artifactId;
   }
 
+  /**
+   * Get the version of the NarInfo instance
+   * @return {@link String} representing a NarInfo object's version.
+   * @since 3.5.3
+   */
+  public String getVersion() {
+      return this.version;
+  }
+
   public final void read(final JarFile jar) throws IOException {
     this.info.load(jar.getInputStream(getNarPropertiesEntry(jar)));
   }

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -160,7 +160,7 @@ public class NarVcprojMojo extends AbstractCompileMojo {
 
     // add linker
     final LinkerDef linkerDefinition = getLinker().getLinker(this, task, getOS(), getAOL().getKey() + ".linker.",
-        type);
+        type, null);
     task.addConfiguredLinker(linkerDefinition);
 
     // add dependency libraries


### PR DESCRIPTION
This change will provide the linker with the path to all of the shared objects that are transitive dependencies if directDepsOnly is enabled.