### PR TITLE
Provide Linux linker with path to transitive dependencies when directDepsOnly is true.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.github.maven-nar</groupId>
   <artifactId>nar-maven-plugin</artifactId>
-  <version>3.6.4-SNAPSHOT</version>
+  <version>3.7.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Native ARchive plugin for Maven</name>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Shared Library Direct</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple shared library that depends on a shared library
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-trans</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/c++/directDep.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/c++/directDep.cpp
@@ -1,0 +1,7 @@
+#include "directDep.h"
+#include "transitiveDep.h"
+
+void directFunction ()
+{
+   transitiveFunction();
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/include/directDep.h
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-direct/src/main/include/directDep.h
@@ -1,0 +1,1 @@
+extern void directFunction();

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-exe</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Transitive Deps Executable</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    An executable program that consumes a transitive dependency which is a shared object
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+          </linker>
+          <libraries>
+            <library>
+              <type>executable</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/src/main/c++/main.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-exe/src/main/c++/main.cpp
@@ -1,0 +1,6 @@
+#include "directDep.h"
+
+int main ()
+{
+   directFunction();
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/pom.xml
@@ -24,28 +24,53 @@
 
   <parent>
     <groupId>com.github.maven-nar.its.nar</groupId>
-    <artifactId>it-parent</artifactId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <relativePath>../it-parent/pom.xml</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
-  <packaging>pom</packaging>
-  <name>Aggregate Direct and Transitive shared objects pom</name>
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-static-lib</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Transitive Deps Static Library</name>
   <version>1.0-SNAPSHOT</version>  
   <description>
-    Aggregate for controlling dependency building order
+    A static library that consumes a transitive dependency which is a shared object
   </description>
   <url>http://maven.apache.org/</url>
 
   <properties>
     <skipTests>true</skipTests>
   </properties>
-  <modules>
-    <module>it0033-directDepsOnly-link-transitive-deps-trans</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-direct</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-exe</module>
-    <module>it0033-directDepsOnly-link-transitive-deps-static-lib</module>
-  </modules>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <directDepsOnly>true</directDepsOnly>
+          <linker>
+            <narDefaultDependencyLibOrder>true</narDefaultDependencyLibOrder>
+          </linker>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
   
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0033-directDepsOnly-link-transitive-deps-direct</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
 </project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/src/main/c++/static.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-static-lib/src/main/c++/static.cpp
@@ -1,0 +1,6 @@
+#include "directDep.h"
+
+void staticFunction()
+{
+  directFunction();
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps-trans</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Shared Library Trans</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple Shared Library
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+    
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/c++/transitiveDep.cpp
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/c++/transitiveDep.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "transitiveDep.h"
+
+void transitiveFunction()
+{
+   std::cout << "This output is coming from the shared object transitive dependency" << std::endl;
+}

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/include/transitiveDep.h
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/it0033-directDepsOnly-link-transitive-deps-trans/src/main/include/transitiveDep.h
@@ -1,0 +1,1 @@
+extern void transitiveFunction();

--- a/src/it/it0033-directDepsOnly-link-transitive-deps/pom.xml
+++ b/src/it/it0033-directDepsOnly-link-transitive-deps/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0033-directDepsOnly-link-transitive-deps</artifactId>
+  <packaging>pom</packaging>
+  <name>Aggregate Direct and Transitive shared objects pom</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Aggregate for controlling dependency building order
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+  <modules>
+    <module>it0033-directDepsOnly-link-transitive-deps-trans</module>
+    <module>it0033-directDepsOnly-link-transitive-deps-direct</module>
+    <module>it0033-directDepsOnly-link-transitive-deps-exe</module>
+  </modules>
+  
+</project>

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -444,10 +444,10 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
     while (it.hasNext()) 
     {
-      it.next();
+      org.eclipse.aether.graph.DependencyNode currentNode = it.next();
       for (org.eclipse.aether.graph.DependencyNode node : nodeList)
       {
-        if (it == node)
+        if (currentNode == node)
         {
           it.remove();
           break;

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -441,17 +441,17 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
   private List<org.eclipse.aether.graph.DependencyNode> trimDuplicates(List<org.eclipse.aether.graph.DependencyNode> nodeList, 
                                                                        List<org.eclipse.aether.graph.DependencyNode> aggDepNodeList)
   {
-    ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
-    while (it.hasNext()) 
+    for (org.eclipse.aether.graph.DependencyNode node : nodeList)
     {
-      org.eclipse.aether.graph.DependencyNode currentNode = it.next();
-      for (org.eclipse.aether.graph.DependencyNode node : nodeList)
+      ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
+      do 
       {
+        org.eclipse.aether.graph.DependencyNode currentNode = it.next();
         if (currentNode == node)
         {
           it.remove();
         }
-      }
+      } while (it.hasNext());
     }
 
     return aggDepNodeList;

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ListIterator;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -383,7 +384,8 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
         new ArrayList<org.eclipse.aether.graph.DependencyNode> ();
     
     // Create list that stores current breadth
-    List <org.eclipse.aether.graph.DependencyNode> NodeChildList = rootNode.getChildren();
+    Set <org.eclipse.aether.graph.DependencyNode> NodeChildList = 
+      new LinkedHashSet<org.eclipse.aether.graph.DependencyNode>(rootNode.getChildren());
 
     // Iterate over each breadth to aggregate the dependency list
     while (!NodeChildList.isEmpty()) {
@@ -412,19 +414,19 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    * @throws MojoExecutionException
    * @since 3.5.2
    */
-  private List<org.eclipse.aether.graph.DependencyNode> levelTraverseVerboseTreeList(
-        List<org.eclipse.aether.graph.DependencyNode>  nodeList, 
+  private Set<org.eclipse.aether.graph.DependencyNode> levelTraverseVerboseTreeList(
+        Set<org.eclipse.aether.graph.DependencyNode>  nodeList, 
         List <org.eclipse.aether.graph.DependencyNode> aggDepNodeList,
         org.eclipse.aether.graph.DependencyNode rootNode) throws MojoExecutionException
   {
-
+    // First remove duplicates in nodeList
     // Compare and trimp duplicates first
     aggDepNodeList = trimDuplicates(nodeList, aggDepNodeList);
 
     aggDepNodeList.addAll(nodeList);
     
-    List<org.eclipse.aether.graph.DependencyNode> NodeChildList = 
-        new ArrayList<org.eclipse.aether.graph.DependencyNode>();
+    Set<org.eclipse.aether.graph.DependencyNode> NodeChildList = 
+        new LinkedHashSet<org.eclipse.aether.graph.DependencyNode>();
     
     for (org.eclipse.aether.graph.DependencyNode node : nodeList) {
       if (nodeArtifactsMatch(rootNode, node)){
@@ -438,7 +440,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     return NodeChildList;
   }
 
-  private List<org.eclipse.aether.graph.DependencyNode> trimDuplicates(List<org.eclipse.aether.graph.DependencyNode> nodeList, 
+  private List<org.eclipse.aether.graph.DependencyNode> trimDuplicates(Set<org.eclipse.aether.graph.DependencyNode> nodeList, 
                                                                        List<org.eclipse.aether.graph.DependencyNode> aggDepNodeList)
   {
     for (org.eclipse.aether.graph.DependencyNode node : nodeList)

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -355,9 +355,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    */
   private List<DependencyNode> levelTraverseTreeList(List<DependencyNode>  nodeList, List <DependencyNode> aggDepNodeList )
   {
-    // Compare and trimp duplicates first
-    aggDepNodeList = trimDuplicates(nodeList, aggDepNodeList);
-
     aggDepNodeList.addAll(nodeList);
     List<DependencyNode> NodeChildList = new ArrayList<DependencyNode>();
     for (DependencyNode node : nodeList) {
@@ -367,25 +364,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     }
 
     return NodeChildList;
-  }
-
-  private List<DependencyNode> trimDuplicates(List<DependencyNode> nodeList, List<DependencyNode> aggDepNodeList)
-  {
-    ListIterator<org.apache.maven.shared.dependency.graph.DependencyNode> it = aggDepNodeList.listIterator();
-    while (it.hasNext()) 
-    {
-      it.next();
-      for (DependencyNode node : nodeList)
-      {
-        if (it == node)
-        {
-          it.remove();
-          break;
-        }
-      }
-    }
-
-    return aggDepNodeList;
   }
 
   /**
@@ -439,6 +417,10 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
         List <org.eclipse.aether.graph.DependencyNode> aggDepNodeList,
         org.eclipse.aether.graph.DependencyNode rootNode) throws MojoExecutionException
   {
+
+    // Compare and trimp duplicates first
+    aggDepNodeList = trimDuplicates(nodeList, aggDepNodeList);
+
     aggDepNodeList.addAll(nodeList);
     
     List<org.eclipse.aether.graph.DependencyNode> NodeChildList = 
@@ -454,6 +436,26 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     }
 
     return NodeChildList;
+  }
+
+  private List<org.eclipse.aether.graph.DependencyNode> trimDuplicates(List<org.eclipse.aether.graph.DependencyNode> nodeList, 
+                                                                       List<org.eclipse.aether.graph.DependencyNode> aggDepNodeList)
+  {
+    ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
+    while (it.hasNext()) 
+    {
+      it.next();
+      for (org.eclipse.aether.graph.DependencyNode node : nodeList)
+      {
+        if (it == node)
+        {
+          it.remove();
+          break;
+        }
+      }
+    }
+
+    return aggDepNodeList;
   }
 
   /**

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -371,7 +371,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
 
   private List<DependencyNode> trimDuplicates(List<DependencyNode> nodeList, List<DependencyNode> aggDepNodeList)
   {
-    getLog.info("In the new function.")
     ListIterator<org.apache.maven.shared.dependency.graph.DependencyNode> it = aggDepNodeList.listIterator();
     while (it.hasNext()) 
     {
@@ -380,7 +379,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
       {
         if (it == node)
         {
-          getLog().info("Duplicate trimmed.");
           it.remove();
           break;
         }

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -355,6 +355,9 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    */
   private List<DependencyNode> levelTraverseTreeList(List<DependencyNode>  nodeList, List <DependencyNode> aggDepNodeList )
   {
+    // Compare and trimp duplicates first
+    aggDepNodeList = trimDuplicates(nodeList, aggDepNodeList);
+
     aggDepNodeList.addAll(nodeList);
     List<DependencyNode> NodeChildList = new ArrayList<DependencyNode>();
     for (DependencyNode node : nodeList) {
@@ -364,6 +367,27 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     }
 
     return NodeChildList;
+  }
+
+  private List<DependencyNode> trimDuplicates(List<DependencyNode> nodeList, List<DependencyNode> aggDepNodeList)
+  {
+    getLog.info("In the new function.")
+    ListIterator<org.apache.maven.shared.dependency.graph.DependencyNode> it = aggDepNodeList.listIterator();
+    while (it.hasNext()) 
+    {
+      it.next();
+      for (DependencyNode node : nodeList)
+      {
+        if (it == node)
+        {
+          getLog().info("Duplicate trimmed.");
+          it.remove();
+          break;
+        }
+      }
+    }
+
+    return aggDepNodeList;
   }
 
   /**
@@ -438,7 +462,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
    * Convenience function for constructing a String representing an artifact in the form "<groupId>:<artifactId>"
    * 
    * @param artifact {@link org.eclipse.aether.Artifact artifact} to construct string from
-   * @return {@link String} in the form <groupId>:<artifactId" representing the artifact
+   * @return {@link String} in the form "<groupId>:<artifactId>" representing the artifact
    * @since 3.5.3
    */
   private String createArtifactString (org.eclipse.aether.artifact.Artifact artifact)

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -450,7 +450,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
         if (currentNode == node)
         {
           it.remove();
-          break;
         }
       }
     }

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -444,14 +444,14 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     for (org.eclipse.aether.graph.DependencyNode node : nodeList)
     {
       ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
-      do 
+      while (it.hasNext()) 
       {
         org.eclipse.aether.graph.DependencyNode currentNode = it.next();
         if (currentNode == node)
         {
           it.remove();
         }
-      } while (it.hasNext());
+      }
     }
 
     return aggDepNodeList;

--- a/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractDependencyMojo.java
@@ -420,8 +420,7 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
         org.eclipse.aether.graph.DependencyNode rootNode) throws MojoExecutionException
   {
     // First remove duplicates in nodeList
-    // Compare and trimp duplicates first
-    aggDepNodeList = trimDuplicates(nodeList, aggDepNodeList);
+    aggDepNodeList.removeAll(nodeList);
 
     aggDepNodeList.addAll(nodeList);
     
@@ -438,25 +437,6 @@ public abstract class AbstractDependencyMojo extends AbstractNarMojo {
     }
 
     return NodeChildList;
-  }
-
-  private List<org.eclipse.aether.graph.DependencyNode> trimDuplicates(Set<org.eclipse.aether.graph.DependencyNode> nodeList, 
-                                                                       List<org.eclipse.aether.graph.DependencyNode> aggDepNodeList)
-  {
-    for (org.eclipse.aether.graph.DependencyNode node : nodeList)
-    {
-      ListIterator<org.eclipse.aether.graph.DependencyNode> it = aggDepNodeList.listIterator();
-      while (it.hasNext()) 
-      {
-        org.eclipse.aether.graph.DependencyNode currentNode = it.next();
-        if (currentNode == node)
-        {
-          it.remove();
-        }
-      }
-    }
-
-    return aggDepNodeList;
   }
 
   /**

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -388,8 +390,10 @@ public class Linker {
     //if No user preference of dependency library link order is specified then use the Default one nar generate.
     if ((this.narDependencyLibOrder == null) && (narDefaultDependencyLibOrder)) {
          if (os.equals(OS.AIX) && (getName(null, null).equals("xlC_r") || getName(null, null).equals("xlC") || getName(null, null).equals("xlc"))){
-            String reverse = new StringBuilder(mojo.dependencyTreeOrderStr(pushDepsToLowestOrder, mojo.getDirectDepsOnly())).reverse().toString();
-            this.narDependencyLibOrder = reverse;
+            String dependencies = new StringBuilder(mojo.dependencyTreeOrderStr(pushDepsToLowestOrder, mojo.getDirectDepsOnly())).toString();
+            List<String> dependency_list = Arrays.asList(dependencies.split("\\s*,\\s*"));
+            Collections.reverse(dependency_list); 
+            this.narDependencyLibOrder = String.join(",", dependency_list);;
          } else {
             this.narDependencyLibOrder = mojo.dependencyTreeOrderStr(pushDepsToLowestOrder, mojo.getDirectDepsOnly());
          }

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -394,8 +394,8 @@ public class Linker {
         mojo.getLog().warn("directDepsOnly will have no effect since narDefaultDependencyLibOrder is disabled");
     }
 
-    // Add transitive dependencies to the shared library search path if we are on linux and directDepsOnly is enabled.
-    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX)){
+    // Add transitive dependencies to the shared library search path if we are on linux, directDepsOnly is enabled, and this is not a static library.
+    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals("static")){
         StringBuilder argStrBuilder = new StringBuilder();
         argStrBuilder.append("-Wl,-rpath-link,");
         for (String path : linkPaths){

--- a/src/main/java/com/github/maven_nar/Linker.java
+++ b/src/main/java/com/github/maven_nar/Linker.java
@@ -395,7 +395,7 @@ public class Linker {
     }
 
     // Add transitive dependencies to the shared library search path if we are on linux, directDepsOnly is enabled, and this is not a static library.
-    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals("static")){
+    if (linkPaths != null && linkPaths.size() > 0 && mojo.getDirectDepsOnly() && os.equals(OS.LINUX) && !type.equals(Library.STATIC)){
         StringBuilder argStrBuilder = new StringBuilder();
         argStrBuilder.append("-Wl,-rpath-link,");
         for (String path : linkPaths){

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 import java.util.Vector;
 import java.util.HashSet;
 import java.util.Properties;
@@ -254,7 +255,8 @@ public class NarCompileMojo extends AbstractCompileMojo {
     getMsvc().configureCCTask(task);
 
     final List<NarArtifact> dependencies = getNarArtifacts();
-    
+    List<String> linkPaths = new ArrayList<String>();
+
     // If we're restricting deps to direct deps ONLY then trim transitive deps
     if (directDepsOnly){
       HashSet<String> directDepsSet = getDirectDepsSet(getVerboseDependencyTree());
@@ -266,6 +268,15 @@ public class NarCompileMojo extends AbstractCompileMojo {
         if(!directDepsSet.contains(dep.getGroupId() + ":" + dep.getArtifactId())){
           this.getLog().warn("Stray dependency: " + dep + " found. This may cause build failures.");
           depsIt.remove();
+          // If this transitive dependency was a shared object, add it to the linkPaths list.
+          String depType = dep.getBinding(null, null);
+          if (Objects.equals(depType, Library.SHARED))
+          {
+            File soDir = getLayout().getLibDirectory(getTargetDirectory(), dep.getArtifactId(), dep.getVersion(), getAOL().toString(), depType);
+            if (soDir.exists()){
+              linkPaths.add(soDir.getAbsolutePath());
+            }
+          }
         }
       }
     }
@@ -294,7 +305,7 @@ public class NarCompileMojo extends AbstractCompileMojo {
     }
 
     // add linker
-    final LinkerDef linkerDefinition = getLinker().getLinker(this, task, getOS(), getAOL().getKey() + ".linker.", type);
+    final LinkerDef linkerDefinition = getLinker().getLinker(this, task, getOS(), getAOL().getKey() + ".linker.", type, linkPaths);
     task.addConfiguredLinker(linkerDefinition);
 
     // add dependency libraries

--- a/src/main/java/com/github/maven_nar/NarVcprojMojo.java
+++ b/src/main/java/com/github/maven_nar/NarVcprojMojo.java
@@ -160,7 +160,7 @@ public class NarVcprojMojo extends AbstractCompileMojo {
 
     // add linker
     final LinkerDef linkerDefinition = getLinker().getLinker(this, task, getOS(), getAOL().getKey() + ".linker.",
-        type);
+        type, null);
     task.addConfiguredLinker(linkerDefinition);
 
     // add dependency libraries


### PR DESCRIPTION
The direct deps only flag gives us control over which libraries get added to the link line, but was also forcing us to specify more dependencies than were really needed.  With these changes we will be able to detect when a transitive dependency will be needed by the linker, and pass the path to the shared library to ld so it will know where to look for the symbols.  It also reduces memory utilization when parsing through the full dependency list by removing duplicates early on in the process.