### PR TITLE
Add environment variables to tests

### DIFF
--- a/src/it/it0007-lib-shared/pom.xml
+++ b/src/it/it0007-lib-shared/pom.xml
@@ -60,6 +60,9 @@
             <test>
               <name>HelloWorldTest</name>
               <link>shared</link>
+              <environmentVariables>
+                <TESTENVVAR>test</TESTENVVAR>
+              </environmentVariables>
             </test>
           </tests>
         </configuration>

--- a/src/it/it0007-lib-shared/src/test/c/HelloWorldTest.c
+++ b/src/it/it0007-lib-shared/src/test/c/HelloWorldTest.c
@@ -18,11 +18,18 @@
  * #L%
  */
 #include <stdio.h>
+#include <stdlib.h>
 #include "HelloWorldLib.h"
 
 int main(int argc, char *argv[]) {
 	printf("%s\n", HelloWorldLib_sayHello());
-	return 0;
+	if(getenv("TESTENVVAR")) {
+	    printf("Found expected test environment variable\n");
+	    return 0;
+	} else {
+	    printf("Did not find expected test environment variable\n");
+	    return 1;
+    }
 }
 
 

--- a/src/main/java/com/github/maven_nar/Test.java
+++ b/src/main/java/com/github/maven_nar/Test.java
@@ -20,7 +20,9 @@
 package com.github.maven_nar;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -72,6 +74,12 @@ public class Test implements Executable {
    */
   @Parameter
   private List<String> dependencyBindings = new ArrayList<>();
+
+  /**
+   * Additional environment variables to set on the command line.
+   */
+  @Parameter
+  private Map<String, String> environmentVariables = new HashMap<>();
   
 
   @Override
@@ -114,6 +122,10 @@ public class Test implements Executable {
 
   public String getType() {
     return this.type;
+  }
+
+  public Map<String, String> getEnvironmentVariables() {
+    return environmentVariables;
   }
 
   @Override


### PR DESCRIPTION
Allow NAR tests to define a map of environment variables to be set
during execution.

Fixes #281.