### PR TITLE
Add 'sharedObjectName' flag to enable shared archives on AIX

### DIFF
--- a/src/it/it-parent/pom.xml
+++ b/src/it/it-parent/pom.xml
@@ -62,4 +62,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>aix-it-profile</id>
+      <activation>
+        <os>
+          <name>aix</name>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>@project.groupId@</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <version>@project.version@</version>
+            <extensions>true</extensions>
+            <configuration>
+              // Need to specifiy linker on AIX otherwise gcc will be assumed and nar-validate goal will fail.
+              <linker>
+                <name>xlC_r</name>
+              </linker>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/it/it0038-sharedObjectName-property/pom.xml
+++ b/src/it/it0038-sharedObjectName-property/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0038-shared-object-name</artifactId>
+  <packaging>nar</packaging>
+
+  <name>NAR Shared Library</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple shared library which uses the sharedObjectName property
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+  
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>shared</type>
+            </library>
+          </libraries>
+          <sharedObjectName>libSharedObject.o</sharedObjectName>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0038-sharedObjectName-property/src/main/c++/HelloWorldLib.cpp
+++ b/src/it/it0038-sharedObjectName-property/src/main/c++/HelloWorldLib.cpp
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+char* HelloWorldLib_sayHello() {
+	return "Hello NAR LIB World!";
+}
+

--- a/src/it/it0038-sharedObjectName-property/src/main/include/HelloWorldLib.h
+++ b/src/it/it0038-sharedObjectName-property/src/main/include/HelloWorldLib.h
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef HelloWorldLib_H
+#define HelloWorldLib_H
+
+#ifdef WIN32
+__declspec(dllexport) 
+#endif
+extern char* HelloWorldLib_sayHello();
+
+#endif

--- a/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractCompileMojo.java
@@ -125,6 +125,13 @@ public abstract class AbstractCompileMojo extends AbstractDependencyMojo {
   protected boolean directDepsOnly;
 
   /**
+   * This parameter only has an effect on the AIX operating system for shared library projects. 
+   * If set, the linker will output a shared object of the given name, 
+   * and that shared object will be added to a shared archive using the normal output name.
+   */
+  @Parameter(defaultValue = "")
+  protected String sharedObjectName;
+  /**
    * List of tests to create
    */
   @Parameter

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -133,6 +133,11 @@ public class NarCompileMojo extends AbstractCompileMojo {
     getLog().debug("NAR - output: '" + outFile + "'");
     task.setOutfile(outFile);
 
+    // If we are building a shared library on AIX and the user has specified a sharedObjectName, use it.
+    if (getOS().equals(OS.AIX) && type.equals(Library.SHARED) && sharedObjectName != "") {
+       task.setSharedObjectName(sharedObjectName);
+    }
+
     // object directory
     File objDir = new File(getTargetDirectory(), "obj");
     objDir = new File(objDir, getAOL().toString());

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -49,6 +49,8 @@ NAR Configuration
   <failOnError/>
   <runtime/>
   <libtool/>
+  <directDepsOnly/>
+  <sharedObjectName/>
   
   <gnuUseOnWindows/>
   <gnuSourceDirectory/>
@@ -89,6 +91,7 @@ NAR Configuration
     <toolPath/>
     <incremental/>
     <map/>
+    <pushDepsToLowestOrder/>
     <options>
       <option/>
     </options>
@@ -265,6 +268,17 @@ Default is dynamic.
 	Set use of libtool. If set to true, the "libtool " will be prepended to 
 the command line for compatible compilers/linkers. Default is false.
 
+* {directDepsOnly}
+
+	If set to true, will force the project to specify all it's 
+dependencies and not inherit transitive dependencies.
+
+* {sharedObjectName}
+
+	This parameter only has an effect on the AIX operating system for shared library projects. 
+If set, the linker will output a shared object of the given name, 
+and that shared object will be added to a shared archive using the normal output name.
+
 * {gnuMakeSkip}
     
     Skip the GNU Make step if you are using the GNU stages. This is useful if you 
@@ -346,6 +360,11 @@ wish to run a GNU configure step but not the full make process.
 ** {linker map}
 
 	Enables the production of a map file. Default is false.
+
+** {linker pushDepsToLowestOrder}
+
+	When true, this property enables linker re-ordering logic such that libraries that 
+are lower in the dependency heirarchy appear lower in the list, maximizing symbol resolution.
 
 ** {linker options}
 


### PR DESCRIPTION
This enhancement will allow users to build shared archives out of their shared library projects. By setting the sharedObjectName property users will set the name of the shared object file which will be added to a shared archive using the output file naming rules before being added to nar file. I also added a test and documentation for this flag as well as two more flags which were recently added but not documented.