### PR TITLE
Removed redundant log entry that pollutes the build log

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CommandExecution.java
@@ -66,7 +66,7 @@ public class CommandExecution {
                 //Append space
                 builder.append(" ");
             }
-            task.log("Executing - " + builder.toString(), Project.MSG_INFO);
+            //task.log("Executing - " + builder.toString(), Project.MSG_INFO);
 
 
             //Create the StreamGobbler to read the process output


### PR DESCRIPTION
I feel that the log statement is inappropriate because it is printed at INFO level so pollutes the build log and detracts from other useful information and/or errors. Even without this log statement the "executed command" can already been seen by passing the -X option.