### PR TITLE
Fix copy libraries bug

### DIFF
--- a/src/main/java/com/github/maven_nar/AbstractResourcesMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractResourcesMojo.java
@@ -99,8 +99,8 @@ public abstract class AbstractResourcesMojo extends AbstractNarMojo {
     int copied = 0;
 
     // copy libraries
-    File libDir = new File(srcDir, this.resourceLibDir);
-    if (libDir.exists()) {
+    File baseLibDir = new File(srcDir, this.resourceLibDir);
+    if (baseLibDir.exists()) {
       // TODO: copyLibraries is used on more than just this artifact - this
       // check needs to be placed elsewhere
       if (getLibraries().isEmpty()) {
@@ -111,6 +111,7 @@ public abstract class AbstractResourcesMojo extends AbstractNarMojo {
         final Library library = (Library) element;
         final String type = library.getType();
 
+        File libDir = baseLibDir;
         final File typedLibDir = new File(libDir, type);
         if (typedLibDir.exists()) {
           libDir = typedLibDir;


### PR DESCRIPTION
If the libraries tag contains more than one library tag
with different types, files of the same type are copied to
all NAR archives.
For example, we want to package a third-party library that
is built both as static and as shared. So pom.xml
contains the following nar-maven-plugin configuration:

    <configuration>
        ...
        <libraries>
            <library>
                <type>static</type>
            </library>
            <library>
                <type>shared</type>
            </library>
        </libraries>
        ...
    </configuration>

Accordingly, native libraries are located as follows:

    src/main/nar/resources/aol/amd64-Linux-gpp/lib/shared/somelib.so
    src/main/nar/resources/aol/amd64-Linux-gpp/lib/static/somelib.lib

Expected that two NAR archives will be generated:
one with a static library, the other with a shared library.

In fact, two NAR archives with the same content are generated.
The content of the archives are determined by the order of the
libraries in the configuration.