### PR TITLE
Feature system includes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -539,6 +539,7 @@
                 <setupInclude>it0031-push-deps-to-lowest-order-agg/pom.xml</setupInclude>
                 <setupInclude>it0034-upstream-aol1-multi-aol/pom.xml</setupInclude>
                 <setupInclude>it0034-upstream-aol2-multi-aol/pom.xml</setupInclude>
+                <setupInclude>it0039-includesTypes/pom.xml</setupInclude>
               </setupIncludes>
               <pomIncludes>
                 <pomInclude>*/pom.xml</pomInclude>

--- a/src/it/it0039-includesTypes-fail/invoker.properties
+++ b/src/it/it0039-includesTypes-fail/invoker.properties
@@ -1,0 +1,2 @@
+# The expected result of the build for this project we WANT the project to fail.
+invoker.buildResult = failure

--- a/src/it/it0039-includesTypes-fail/pom.xml
+++ b/src/it/it0039-includesTypes-fail/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>it0039-testLibs-fail</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>it0039-testLibs-fail</name>
+  <version>1.0-SNAPSHOT</version>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>executable</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0039-without-system-createLibs</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0039-includesTypes-fail/src/main/c/prog.c
+++ b/src/it/it0039-includesTypes-fail/src/main/c/prog.c
@@ -1,0 +1,1 @@
+#include "test.h"

--- a/src/it/it0039-includesTypes-succeed/pom.xml
+++ b/src/it/it0039-includesTypes-succeed/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>it0039-testLibs-succeed</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>it0039-testLibs-succeed</name>
+  <version>1.0-SNAPSHOT</version>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>executable</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0039-with-system-createLibs</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0039-includesTypes-succeed/src/main/c/prog.c
+++ b/src/it/it0039-includesTypes-succeed/src/main/c/prog.c
@@ -1,0 +1,1 @@
+#include "test.h"

--- a/src/it/it0039-includesTypes/it0039-with-system-createLibs/pom.xml
+++ b/src/it/it0039-includesTypes/it0039-with-system-createLibs/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../it-parent/pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>it0039-with-system-createLibs</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>it0039-with-system-createLibs</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Simple test for GNU package
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <includesType>system</includesType>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/c/test.c
+++ b/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/c/test.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/include/test.h
+++ b/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/include/test.h
@@ -1,0 +1,25 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+#ifdef __GNUC__
+#pragma GCC diagnostic error "-Werror"
+#endif
+
+int testWithWarning() {}

--- a/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/include/test.h
+++ b/src/it/it0039-includesTypes/it0039-with-system-createLibs/src/main/include/test.h
@@ -19,7 +19,7 @@
  */
 
 #ifdef __GNUC__
-#pragma GCC diagnostic error "-Werror"
+#pragma GCC diagnostic error "-Wreturn-type"
 #endif
 
 int testWithWarning() {}

--- a/src/it/it0039-includesTypes/it0039-without-system-createLibs/pom.xml
+++ b/src/it/it0039-includesTypes/it0039-without-system-createLibs/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../../it-parent/pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>it0039-without-system-createLibs</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>it0039-without-system-createLibs</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Simple test for GNU package
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>static</type>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/c/test.c
+++ b/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/c/test.c
@@ -1,0 +1,1 @@
+int main() { return 0; }

--- a/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/include/test.h
+++ b/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/include/test.h
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+#ifdef __GNUC__
+#pragma GCC diagnostic error "-Werror"
+#pragma GCC diagnostic error "-Werror"
+#endif
+
+int testWithWarning() {}

--- a/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/include/test.h
+++ b/src/it/it0039-includesTypes/it0039-without-system-createLibs/src/main/include/test.h
@@ -19,8 +19,7 @@
  */
 
 #ifdef __GNUC__
-#pragma GCC diagnostic error "-Werror"
-#pragma GCC diagnostic error "-Werror"
+#pragma GCC diagnostic error "-Wreturn-type"
 #endif
 
 int testWithWarning() {}

--- a/src/it/it0039-includesTypes/pom.xml
+++ b/src/it/it0039-includesTypes/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+  
+  <artifactId>it0039-includesType</artifactId>
+  <packaging>pom</packaging>
+  
+  <name>it0039-includesType</name>
+  <version>1.0-SNAPSHOT</version>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+  </build>
+  
+  <modules>
+    <module>it0039-without-system-createLibs</module>
+    <module>it0039-with-system-createLibs</module>
+  </modules>
+</project>

--- a/src/main/java/com/github/maven_nar/AbstractNarMojo.java
+++ b/src/main/java/com/github/maven_nar/AbstractNarMojo.java
@@ -165,6 +165,13 @@ public abstract class AbstractNarMojo extends AbstractMojo implements NarConstan
   private boolean skipRanlib;
 
   /**
+   * Specifies the type of include this artifact may contain -- system
+   * or local (default)
+   */
+  @Parameter(defaultValue = "local", required = true)
+  private String includesType;
+
+  /**
    * Layout to be used for building and unpacking artifacts
    */
   @Parameter(property = "nar.layout", defaultValue = "com.github.maven_nar.NarLayout21", required = true)
@@ -354,6 +361,10 @@ public abstract class AbstractNarMojo extends AbstractMojo implements NarConstan
   
   protected final boolean isSkipRanlib() throws MojoExecutionException {
     return this.skipRanlib;
+  }
+
+  protected final String getIncludesType() throws MojoExecutionException {
+    return this.includesType;
   }
 
   protected final File getOutputDirectory() {

--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -445,6 +445,7 @@ public abstract class Compiler {
       if (!includePath.exists()) {
         throw new MojoFailureException("NAR: Include path not found: " + includePath);
       }
+      mojo.getLog().info("include: " + includePath.getPath());
       compilerDef.createIncludePath().setPath(includePath.getPath());
     }
 

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -295,7 +295,13 @@ public class NarCompileMojo extends AbstractCompileMojo {
             narDependency.getBaseVersion());
         getLog().debug("Looking for include directory: " + include);
         if (include.exists()) {
-          task.createIncludePath().setPath(include.getPath());
+          String includesType = narDependency.getNarInfo().getInludesType(null);
+          if (includesType.equals("system")) {
+            task.createSysIncludePath().setPath(include.getPath());
+          }
+          else {
+            task.createIncludePath().setPath(include.getPath());
+          }
         } else {
           // Ideally includes are used from lib (static or shared)
           // however it's not required.

--- a/src/main/java/com/github/maven_nar/NarInfo.java
+++ b/src/main/java/com/github/maven_nar/NarInfo.java
@@ -115,6 +115,10 @@ public class NarInfo {
     // resolve output Vs libs.names
     return getProperty(aol, "libs.names", getOutput(aol, this.artifactId + "-" + this.version));
   }
+  
+  public final String getInludesType(final AOL aol) {
+    return getProperty(aol, "inludes.type", "local");
+  }
 
   public String getNarInfoFileName() {
     return "META-INF/nar/" + this.groupId + "/" + this.artifactId + "/" + NAR_PROPERTIES;
@@ -216,6 +220,10 @@ public class NarInfo {
 
   public final void setLibs(final AOL aol, final String value) {
     setProperty(aol, "libs.names", value);
+  }
+  
+  public final void setInludesType(final AOL aol, final String value) {
+    setProperty(aol, "inludes.type", value);
   }
 
   private void setProperty(final AOL aol, final String key, final String value) {

--- a/src/main/java/com/github/maven_nar/NarLayout21.java
+++ b/src/main/java/com/github/maven_nar/NarLayout21.java
@@ -217,6 +217,8 @@ public class NarLayout21 extends AbstractNarLayout {
         if (mojo.getLibsName() != null) {
           narInfo.setLibs(aol, mojo.getLibsName());
         }
+        
+        narInfo.setInludesType(null, mojo.getIncludesType());
 
         // We prefer shared to jni/executable/static/none,
         if (type.equals(Library.SHARED)) // overwrite whatever we had

--- a/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarTestCompileMojo.java
@@ -171,7 +171,7 @@ public class NarTestCompileMojo extends AbstractCompileMojo {
     
     // add dependency include paths
     for (final Object depLib1 : dependencies) {
-      final Artifact artifact = (Artifact) depLib1;
+      final NarArtifact artifact = (NarArtifact) depLib1;
 
       // check if it exists in the normal unpack directory
       File include = getLayout()
@@ -182,7 +182,13 @@ public class NarTestCompileMojo extends AbstractCompileMojo {
             .getIncludeDirectory(getTestUnpackDirectory(), artifact.getArtifactId(), artifact.getBaseVersion());
       }
       if (include.exists()) {
-        task.createIncludePath().setPath(include.getPath());
+        String includesType = artifact.getNarInfo().getInludesType(null);
+        if (includesType.equals("system")) {
+          task.createSysIncludePath().setPath(include.getPath());
+        }
+        else {
+          task.createIncludePath().setPath(include.getPath());
+        }
       }
     }
 

--- a/src/site/apt/configuration.apt
+++ b/src/site/apt/configuration.apt
@@ -51,6 +51,7 @@ NAR Configuration
   <libtool/>
   <directDepsOnly/>
   <sharedObjectName/>
+  <includesType/>
   
   <gnuUseOnWindows/>
   <gnuSourceDirectory/>
@@ -279,6 +280,11 @@ dependencies and not inherit transitive dependencies.
 	This parameter only has an effect on the AIX operating system for shared library projects. 
 If set, the linker will output a shared object of the given name, 
 and that shared object will be added to a shared archive using the normal output name.
+
+* {includesType}
+
+  Specifies whether a dependent artifact should include headers as system files or regular
+  local files. Possible values are system and local. Default is local.
 
 * {gnuMakeSkip}
     


### PR DESCRIPTION
This PR allows you to specify whether dependent projects should treat included header files as system headers (and thus ignoring warnings).

At my company we package most of our projects' system dependencies as nar artifacts. Things like boost, googletest, fftw etc. However, the problem with this approach is that the headers from these projects aren't treated as system headers by g++ because nar specifies them with the -I flag (and not -isystem).

Consequently, our build logs are polluted with a bunch of warnings from system headers. This PR allows you to specify via the `includesType` option whether the artifact headers should be treated as a system headers by dependent projects.

There are a couple of problems with this PR however so I am not sure it should be accepted as-is.

1. The integration test is GCC-only as it enables -Werror in order to fail the failure case. We are a linux only shop so I don't have the resources (or ability...) to write a visual studio test case.
2. The way this works is that it writes out the `includesType=system|local` line to the generated nar.properties file. The problem with this approach is that the nar.properties file is not included in the noarch attachment only AOL-specific ones. See file 'NarPreparePackageMojo.java'.

What that final bullet implies is that the option will have no effect if the artifact is a header-only library and only has a noarch artifact. That is why the test cases actually build a library when they otherwise need not. I am not sure of an easy solution to this problem without changing some significant parts of the plugin so I am accepting of the limitation as is. Feedback, of course, is welcome.