### PR TITLE
Support Linux on PPC64LE

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -576,6 +576,46 @@ arm.Linux.gcc.plugin.extension=so
 arm.Linux.gcc.jni.extension=so
 
 #
+# PPC64LE Linux
+#
+ppc64le.Linux.linker=g++
+
+ppc64le.Linux.gpp.cpp.compiler=g++
+ppc64le.Linux.gpp.cpp.defines=Linux GNU_GCC
+ppc64le.Linux.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC -m64
+ppc64le.Linux.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+ppc64le.Linux.gpp.cpp.excludes=
+
+ppc64le.Linux.gpp.c.compiler=gcc
+ppc64le.Linux.gpp.c.defines=Linux GNU_GCC
+ppc64le.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC -m64
+ppc64le.Linux.gpp.c.includes=**/*.c
+ppc64le.Linux.gpp.c.excludes=
+
+ppc64le.Linux.gpp.fortran.compiler=gfortran
+ppc64le.Linux.gpp.fortran.defines=Linux GNU_GCC
+ppc64le.Linux.gpp.fortran.options=-Wall
+ppc64le.Linux.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+ppc64le.Linux.gpp.fortran.excludes=
+
+ppc64le.Linux.gpp.java.include=include;include/linux
+ppc64le.Linux.gpp.java.runtimeDirectory=jre/lib/ppc64le/server
+
+ppc64le.Linux.gpp.lib.prefix=lib
+ppc64le.Linux.gpp.shared.prefix=lib
+ppc64le.Linux.gpp.static.extension=a
+ppc64le.Linux.gpp.shared.extension=so*
+ppc64le.Linux.gpp.plugin.extension=so
+ppc64le.Linux.gpp.jni.extension=so
+ppc64le.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+ppc64le.Linux.gcc.static.extension=a
+ppc64le.Linux.gcc.shared.extension=so*
+ppc64le.Linux.gcc.plugin.extension=so
+ppc64le.Linux.gcc.jni.extension=so
+
+#
 # MacOSX ("Mac OS X" => MacOSX) PowerPC
 #
 ppc.MacOSX.linker=g++


### PR DESCRIPTION
Compiling https://github.com/tada/pljava on Debian's ppc64el
architecture failed because nar doesn't support the platform. Fix by
copying the amd64.Linux definitions and substituting s/amd64/ppc64le/g.