### PR TITLE
Support aarch64 (arm64) Linux

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -576,6 +576,48 @@ arm.Linux.gcc.plugin.extension=so
 arm.Linux.gcc.jni.extension=so
 
 #
+# aarch64 (arm64) Linux
+#
+aarch64.Linux.linker=g++
+
+aarch64.Linux.gpp.cpp.compiler=g++
+aarch64.Linux.gpp.cpp.defines=Linux GNU_GCC
+aarch64.Linux.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC
+aarch64.Linux.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+aarch64.Linux.gpp.cpp.excludes=
+
+aarch64.Linux.gpp.c.compiler=gcc
+aarch64.Linux.gpp.c.defines=Linux GNU_GCC
+aarch64.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC
+aarch64.Linux.gpp.c.includes=**/*.c
+aarch64.Linux.gpp.c.excludes=
+
+aarch64.Linux.gpp.fortran.compiler=gfortran
+aarch64.Linux.gpp.fortran.defines=Linux GNU_GCC
+aarch64.Linux.gpp.fortran.options=-Wall
+aarch64.Linux.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+aarch64.Linux.gpp.fortran.excludes=
+
+aarch64.Linux.gpp.java.include=include;include/linux
+aarch64.Linux.gpp.java.runtimeDirectory=jre/lib/aarch64/server
+
+aarch64.Linux.gpp.lib.prefix=lib
+aarch64.Linux.gpp.shared.prefix=lib
+aarch64.Linux.gpp.static.extension=a
+aarch64.Linux.gpp.shared.extension=so*
+aarch64.Linux.gpp.plugin.extension=so
+aarch64.Linux.gpp.jni.extension=so
+aarch64.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+aarch64.Linux.gcc.static.extension=a
+aarch64.Linux.gcc.shared.extension=so*
+aarch64.Linux.gcc.plugin.extension=so
+aarch64.Linux.gcc.jni.extension=so
+
+#aarch64.Linux.gpp.arch.includes=lib/**/*.a lib/**/*.so
+
+#
 # PPC64LE Linux
 #
 ppc64le.Linux.linker=g++


### PR DESCRIPTION
Like in 086f6b3e (#328), this is to support compiling
https://github.com/tada/pljava, this time on the aarch64 (called arm64
in Debian) platform. This is the amd64.Linux definitios copied, the
architecture name replaced, and "-m64" removed because it's not a valid
flag on that architecture.