### PR TITLE
Support Linux gcc on sparc64 and sparc

### DIFF
--- a/src/main/resources/com/github/maven_nar/aol.properties
+++ b/src/main/resources/com/github/maven_nar/aol.properties
@@ -616,6 +616,86 @@ ppc64le.Linux.gcc.plugin.extension=so
 ppc64le.Linux.gcc.jni.extension=so
 
 #
+# Linux sparc64 gcc
+#
+sparcv9.Linux.linker=g++
+
+sparcv9.Linux.gpp.cpp.compiler=g++
+sparcv9.Linux.gpp.cpp.defines=Linux GNU_GCC
+sparcv9.Linux.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC -m64
+sparcv9.Linux.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+sparcv9.Linux.gpp.cpp.excludes=
+
+sparcv9.Linux.gpp.c.compiler=gcc
+sparcv9.Linux.gpp.c.defines=Linux GNU_GCC
+sparcv9.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -fPIC -m64
+sparcv9.Linux.gpp.c.includes=**/*.c
+sparcv9.Linux.gpp.c.excludes=
+
+sparcv9.Linux.gpp.fortran.compiler=gfortran
+sparcv9.Linux.gpp.fortran.defines=Linux GNU_GCC
+sparcv9.Linux.gpp.fortran.options=-Wall
+sparcv9.Linux.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+sparcv9.Linux.gpp.fortran.excludes=
+
+sparcv9.Linux.gpp.java.include=include;include/linux
+sparcv9.Linux.gpp.java.runtimeDirectory=jre/lib/sparcv9/server
+
+sparcv9.Linux.gpp.lib.prefix=lib
+sparcv9.Linux.gpp.shared.prefix=lib
+sparcv9.Linux.gpp.static.extension=a
+sparcv9.Linux.gpp.shared.extension=so*
+sparcv9.Linux.gpp.plugin.extension=so
+sparcv9.Linux.gpp.jni.extension=so
+sparcv9.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+sparcv9.Linux.gcc.static.extension=a
+sparcv9.Linux.gcc.shared.extension=so*
+sparcv9.Linux.gcc.plugin.extension=so
+sparcv9.Linux.gcc.jni.extension=so
+
+#
+# Linux sparc gcc
+#
+sparc.Linux.linker=g++
+
+sparc.Linux.gpp.cpp.compiler=g++
+sparc.Linux.gpp.cpp.defines=Linux GNU_GCC
+sparc.Linux.gpp.cpp.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -m32
+sparc.Linux.gpp.cpp.includes=**/*.cc **/*.cpp **/*.cxx
+sparc.Linux.gpp.cpp.excludes=
+
+sparc.Linux.gpp.c.compiler=gcc
+sparc.Linux.gpp.c.defines=Linux GNU_GCC
+sparc.Linux.gpp.c.options=-Wall -Wno-long-long -Wpointer-arith -Wconversion -m32
+sparc.Linux.gpp.c.includes=**/*.c
+sparc.Linux.gpp.c.excludes=
+
+sparc.Linux.gpp.fortran.compiler=gfortran
+sparc.Linux.gpp.fortran.defines=Linux GNU_GCC
+sparc.Linux.gpp.fortran.options=-Wall
+sparc.Linux.gpp.fortran.includes=**/*.f **/*.for **/*.f90
+sparc.Linux.gpp.fortran.excludes=
+
+sparc.Linux.gpp.java.include=include;include/linux
+sparc.Linux.gpp.java.runtimeDirectory=jre/lib/sparc/server
+
+sparc.Linux.gpp.lib.prefix=lib
+sparc.Linux.gpp.shared.prefix=lib
+sparc.Linux.gpp.static.extension=a
+sparc.Linux.gpp.shared.extension=so*
+sparc.Linux.gpp.plugin.extension=so
+sparc.Linux.gpp.jni.extension=so
+sparc.Linux.gpp.executable.extension=
+
+# FIXME to be removed when NAR-6
+sparc.Linux.gcc.static.extension=a
+sparc.Linux.gcc.shared.extension=so*
+sparc.Linux.gcc.plugin.extension=so
+sparc.Linux.gcc.jni.extension=so
+
+#
 # MacOSX ("Mac OS X" => MacOSX) PowerPC
 #
 ppc.MacOSX.linker=g++


### PR DESCRIPTION
Compiling https://github.com/tada/pljava on Debian's sparc64 and sparc
architectures failed because nar doesn't support those platforms. With
these properties pljava builds successfully on Debian sparc64 (tested on
Buster) and Debian sparc (tested on Jessie).