### PR TITLE
NarUtil: handle null Linker parameter to getAOL(...) as intended

### DIFF
--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -257,7 +257,7 @@ public final class NarUtil {
     * */
     String aol_linker;
 
-    if(linker != null & linker.getName() != null)
+    if(linker != null && linker.getName() != null)
     {
       log.debug("linker original name: " + linker.getName());
       aol_linker = linker.getName();


### PR DESCRIPTION
Previously we were throwing a NullPointerException if we had a null
Linker passed in, because of the line:
    if(linker != null & linker.getName() != null)

This change simply changes that single-ampersand to a double-ampersand
which is the behaviour the original author intended.