### PR TITLE
Fixed VS 2019 by using env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In your POM:
 		<plugin>
 			<groupId>com.github.maven-nar</groupId>
 			<artifactId>nar-maven-plugin</artifactId>
-			<version>3.5.1</version>
+			<version>3.10.2-SNAPSHOT</version>
 			<extensions>true</extensions>
 			<configuration>
 				...

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.9.15</version>
+      <version>1.10.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.bcel</groupId>
@@ -229,12 +229,12 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.17</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>2.4.4</version>
+      <version>4.2.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.codehaus.plexus</groupId>
@@ -399,7 +399,7 @@
               <configuration>
                   <rules>
                       <enforceBytecodeVersion>
-                          <maxJdkVersion>1.7</maxJdkVersion>
+                          <maxJdkVersion>1.8</maxJdkVersion>
                       </enforceBytecodeVersion>
                   </rules>
                   <fail>true</fail>

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -10,11 +10,9 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.sun.jna.platform.win32.Advapi32Util;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.tools.ant.types.Environment.Variable;
 import org.codehaus.plexus.util.StringUtils;
 
@@ -44,6 +42,7 @@ public class Msvc {
    * <li>12.0 for VS 2013</li>
    * <li>14.0 for VS 2015</li>
    * <li>15.0 for VS 2017</li>
+   * <li>16.0 for VS 2019</li>
    * </ul>
    */
   private String version = "";
@@ -287,7 +286,7 @@ public class Msvc {
       }
 
       // Visual Studio
-      if (compareVersion(version, "15.0") < 0) {
+      if (compareVersion(version, "16.0") < 0) {
         if ("x86".equals(arch)) {
           linker.addLibraryDirectory(msvctoolhome, "lib");
           linker.addLibraryDirectory(msvctoolhome, "atlmfc/lib");
@@ -368,7 +367,7 @@ public class Msvc {
   private void initPath(CrossCompilers compiler) throws MojoExecutionException {
 
     Boolean found = true;
-    if (compareVersion(version, "15.0") < 0) {
+    if (compareVersion(version, "16.0") < 0) {
       switch (compiler) {
         case x86:
           // compile using x86 tools.
@@ -447,7 +446,7 @@ public class Msvc {
     }
 
     // tools that are more generic
-    if (compareVersion(version, "15.0") < 0) {
+    if (compareVersion(version, "16.0") < 0) {
       addPath(msvctoolhome, "VCPackages");
       addPath(home, "Common7/Tools");
       addPath(home, "Common7/IDE");
@@ -540,6 +539,29 @@ public class Msvc {
   private void initVisualStudio() throws MojoFailureException, MojoExecutionException {
     mojo.getLog().debug(" -- Searching for usable VisualStudio ");
 
+    /* New env values used by VS 2019
+    VCIDEInstallDir=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VC\
+    VCINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\
+    VCToolsInstallDir=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.28.29333\
+    VCToolsRedistDir=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Redist\MSVC\14.28.29325\
+    VCToolsVersion=14.28.29333
+    VisualStudioVersion=16.0
+    VS160COMNTOOLS=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\Tools\
+    VSCMD_ARG_app_plat=Desktop
+    VSCMD_ARG_HOST_ARCH=x64
+    VSCMD_ARG_TGT_ARCH=x64
+    VSCMD_VER=16.8.5
+    VSINSTALLDIR=C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\
+    WindowsLibPath=C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0;C:\Program Files (x86)\Windows Kits\10\References\10.0.18362.0
+    WindowsSdkBinPath=C:\Program Files (x86)\Windows Kits\10\bin\
+    WindowsSdkDir=C:\Program Files (x86)\Windows Kits\10\
+    WindowsSDKLibVersion=10.0.18362.0\
+    WindowsSdkVerBinPath=C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\
+    WindowsSDKVersion=10.0.18362.0\ 
+    */
+    // examine the VS version variable first before attempting to read older registry entries which are not supported in later VS versions
+    this.version = System.getenv("VisualStudioVersion");
+
     mojo.getLog().debug("Requested Linker version is  \"" + version + "\"");
 
     if (version != null && version.trim().length() > 1) {
@@ -557,8 +579,9 @@ public class Msvc {
         // @<Major.Minor>
         try {
           home = new File(registryGet32StringValue(com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE,
-              "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7", version));
-        } finally {
+          "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7", version));
+        } catch (Exception e) {
+          // is there interest in knowing about an Win32Exception here for newer VS versions?
         }
       }
       if (home == null || !home.exists()) {
@@ -571,7 +594,8 @@ public class Msvc {
         }
       }
       mojo.getLog().debug(String.format(" VisualStudio %1s (%2s) found %3s ", version, internalVersion, home));
-    } else {
+    } else {  
+      // reset
       this.version = ""; //
       // First search registry for installed items, more reliable than environment.
       for (final Entry<String, Object> entry : visualStudioVS7SxS(com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE,
@@ -826,7 +850,7 @@ public class Msvc {
   }
 
   private File VCToolHome() {
-    if (compareVersion(version, "15.0") < 0) {
+    if (compareVersion(version, "16.0") < 0) {
       return new File(home, "VC/");
     } else {
       final File msvcversionFile = new File(home, "VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt");

--- a/src/main/java/com/github/maven_nar/Msvc.java
+++ b/src/main/java/com/github/maven_nar/Msvc.java
@@ -286,7 +286,7 @@ public class Msvc {
       }
 
       // Visual Studio
-      if (compareVersion(version, "16.0") < 0) {
+      if (compareVersion(version, "15.0") < 0) {
         if ("x86".equals(arch)) {
           linker.addLibraryDirectory(msvctoolhome, "lib");
           linker.addLibraryDirectory(msvctoolhome, "atlmfc/lib");
@@ -367,7 +367,7 @@ public class Msvc {
   private void initPath(CrossCompilers compiler) throws MojoExecutionException {
 
     Boolean found = true;
-    if (compareVersion(version, "16.0") < 0) {
+    if (compareVersion(version, "15.0") < 0) {
       switch (compiler) {
         case x86:
           // compile using x86 tools.
@@ -446,7 +446,7 @@ public class Msvc {
     }
 
     // tools that are more generic
-    if (compareVersion(version, "16.0") < 0) {
+    if (compareVersion(version, "15.0") < 0) {
       addPath(msvctoolhome, "VCPackages");
       addPath(home, "Common7/Tools");
       addPath(home, "Common7/IDE");
@@ -559,11 +559,15 @@ public class Msvc {
     WindowsSdkVerBinPath=C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\
     WindowsSDKVersion=10.0.18362.0\ 
     */
-    // examine the VS version variable first before attempting to read older registry entries which are not supported in later VS versions
-    this.version = System.getenv("VisualStudioVersion");
-
+    // don't attempt to subvert the version setting from the pom
+    if (version == null || version.trim().length() < 1) {
+      // examine the VS version variable before attempting to read older registry entries which are not supported in later VS versions
+      String envVisualStudioVersion = System.getenv("VisualStudioVersion");
+      if (envVisualStudioVersion != null && envVisualStudioVersion.length() > 3) {
+        this.version = envVisualStudioVersion;
+      }
+    }
     mojo.getLog().debug("Requested Linker version is  \"" + version + "\"");
-
     if (version != null && version.trim().length() > 1) {
       String internalVersion;
       Pattern r = Pattern.compile("(\\d+)\\.*(\\d)");
@@ -596,7 +600,7 @@ public class Msvc {
       mojo.getLog().debug(String.format(" VisualStudio %1s (%2s) found %3s ", version, internalVersion, home));
     } else {  
       // reset
-      this.version = ""; //
+      this.version = "";
       // First search registry for installed items, more reliable than environment.
       for (final Entry<String, Object> entry : visualStudioVS7SxS(com.sun.jna.platform.win32.WinReg.HKEY_LOCAL_MACHINE,
           "SOFTWARE\\Microsoft\\VisualStudio\\SxS\\VS7").entrySet()) {
@@ -850,7 +854,7 @@ public class Msvc {
   }
 
   private File VCToolHome() {
-    if (compareVersion(version, "16.0") < 0) {
+    if (compareVersion(version, "15.0") < 0) {
       return new File(home, "VC/");
     } else {
       final File msvcversionFile = new File(home, "VC/Auxiliary/Build/Microsoft.VCToolsVersion.default.txt");

--- a/src/main/java/com/github/maven_nar/NarProperties.java
+++ b/src/main/java/com/github/maven_nar/NarProperties.java
@@ -86,7 +86,13 @@ public class NarProperties {
    *          the properties from input stream
    */
   public static void inject(final MavenProject project, final InputStream properties) throws MojoFailureException {
-    final Properties defaults = PropertyUtils.loadProperties(properties);
+    Properties defaults;
+    try {
+      defaults = PropertyUtils.loadProperties(properties);
+    } catch (IOException e) {
+      // re-throw as a mojo failure
+      throw new MojoFailureException("IOException loading properties", e);
+    }
     final NarProperties nar = getInstance(project);
     nar.properties.putAll(defaults);
   }
@@ -95,7 +101,13 @@ public class NarProperties {
 
   private NarProperties(final MavenProject project, File narFile, String customPropertyLocation) throws MojoFailureException {
 
-    final Properties defaults = PropertyUtils.loadProperties(NarUtil.class.getResourceAsStream(AOL_PROPERTIES));
+    Properties defaults;
+    try {
+      defaults = PropertyUtils.loadProperties(NarUtil.class.getResourceAsStream(AOL_PROPERTIES));
+    } catch (IOException e) {
+      // re-throw as a mojo failure
+      throw new MojoFailureException("IOException loading properties", e);
+    }
     if (defaults == null) {
       throw new MojoFailureException("NAR: Could not load default properties file: '" + AOL_PROPERTIES + "'.");
     }
@@ -107,13 +119,14 @@ public class NarProperties {
         fis = new FileInputStream(narFile);
         this.properties.load(fis);
       }
-    } catch (final FileNotFoundException e) {
+    } catch (FileNotFoundException e) {
       if (customPropertyLocation != null) {
         // We tried loading from a custom location - so throw the exception
         throw new MojoFailureException("NAR: Could not load custom properties file: '" + customPropertyLocation + "'.");
       }
-    } catch (final IOException e) {
-      // ignore (FIXME)
+    } catch (IOException e) {
+      // re-throw as a mojo failure
+      throw new MojoFailureException("IOException loading properties", e);
     } finally {
       try {
         if (fis != null) {


### PR DESCRIPTION
This fix allows VisualStudio 2019 to work by utilizing env variables. Previously this was broken due to the plugins use of the registry, for which the VisualStudio product no longer makes the searched entries.