### PR TITLE
Increase the minimum required JDK version to 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
               <configuration>
                   <rules>
                       <enforceBytecodeVersion>
-                          <maxJdkVersion>1.7</maxJdkVersion>
+                          <maxJdkVersion>1.8</maxJdkVersion>
                       </enforceBytecodeVersion>
                   </rules>
                   <fail>true</fail>


### PR DESCRIPTION
Required for updated dependencies ant, commons-io