### PR TITLE
Fix NPE msvc .res build

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CCTask.java
@@ -994,7 +994,11 @@ public class CCTask extends Task {
                   if (compileException == null && exception instanceof BuildException) {
                     compileException = (BuildException) exception;
                   } else {
-                    log(cores[j].getName() + " " + exception + "                                  ", Project.MSG_ERR);
+                    log(cores[j].getName() + " " + exception + " ", Project.MSG_ERR);
+                    final StackTraceElement[] stackTrace = exception.getStackTrace();
+                    for (final StackTraceElement element : stackTrace) {
+                      log(element.toString(),Project.MSG_DEBUG);
+                    }
                   }
                   if (!this.relentless) {
                     cores[j] = null;

--- a/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/compiler/CommandLineCompiler.java
@@ -571,7 +571,8 @@ public abstract class CommandLineCompiler extends AbstractCompiler {
    * arguments without actually spawning the compiler
    */
   protected int runCommand(final CCTask task, final File workingDir, final String[] cmdline) throws BuildException {
-    commands.add(cmdline);
+    if(commands!=null)
+      commands.add(cmdline);
     if (dryRun) return 0;
     return CUtil.runCommand(task, workingDir, cmdline, this.newEnvironment, this.env);
   }


### PR DESCRIPTION
The `commands` list was not initialized for resource compilation. 
Not clear on any need to do so, chosen to simply check for null and skip step of adding command