### PR TITLE
Fix the dependency path order when executing tests

### DIFF
--- a/src/main/java/com/github/maven_nar/NarUtil.java
+++ b/src/main/java/com/github/maven_nar/NarUtil.java
@@ -109,7 +109,7 @@ public final class NarUtil {
     String libPath = path;
     libPath = libPath.replace(File.pathSeparatorChar, separator);
     if (value != null) {
-      value += separator + libPath;
+      value = libPath + separator + value; // items under test first on path
     } else {
       value = libPath;
     }


### PR DESCRIPTION
Several times had build failures due to having older product
installed and so having conflicting dependencies in the path

Dependencies should be taken in preference,
so putting them first in the path