### PR TITLE
Feature default binding supporting multiple bindings static/shared

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,7 @@
 
   <properties>
     <invoker.debug>false</invoker.debug>
+    <invoker.workspace>${project.build.directory}/it</invoker.workspace>
     <its.to.skip>dummy</its.to.skip>
     <mavenVersion>3.0.4</mavenVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -541,6 +542,7 @@
             <artifactId>maven-invoker-plugin</artifactId>
             <version>3.2.0</version>
             <configuration>
+              <cloneProjectsTo>${invoker.workspace}</cloneProjectsTo>
               <properties>
                 <jna.nosys>true</jna.nosys>
               </properties>

--- a/src/it/it-parent/pom.xml
+++ b/src/it/it-parent/pom.xml
@@ -88,5 +88,33 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>java-10+</id>
+      <activation>
+        <jdk>[10,)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.maven-nar</groupId>
+            <artifactId>nar-maven-plugin</artifactId>
+            <configuration>
+              <javah>
+                <skip>true</skip>
+              </javah>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArguments>
+                <h>${project.build.directory}/nar/javah-include</h>
+              </compilerArguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-default/pom.xml
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-default/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0040-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0040-dep-lib-default</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Executable and default Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Executable depending on a library from a mixed type with default linkage.
+  </description>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <c>
+            <defines>
+              <define>LIB_IMPORTS</define>
+            </defines>
+          </c>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <!-- <linkCPP>false</linkCPP> -->
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0040-lib-sharedstatic</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-default/src/main/c/HelloWorldExe.c
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-default/src/main/c/HelloWorldExe.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+int main(int argc, char *argv[]) {
+	printf("%s\n", HelloWorldLib_sayHello());
+	return 0;
+}
+
+

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-shared/pom.xml
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-shared/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0040-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0040-dep-lib-shared</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Executable and Shared Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Executable depending on a shared library from a mixed type.
+  </description>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <c>
+            <defines>
+              <define>LIB_IMPORTS</define>
+            </defines>
+          </c>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <!-- <linkCPP>false</linkCPP> -->
+              <dependencyBindings>
+                <dependencyBinding>it0040-lib-sharedstatic:shared</dependencyBinding>
+              </dependencyBindings>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0040-lib-sharedstatic</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-shared/src/main/c/HelloWorldExe.c
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-shared/src/main/c/HelloWorldExe.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+int main(int argc, char *argv[]) {
+	printf("%s\n", HelloWorldLib_sayHello());
+	return 0;
+}
+
+

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-static/pom.xml
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-static/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0040-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0040-dep-lib-static</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Executable and Static Library</name>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Executable depending on a static library from a mixed type.
+  </description>
+  
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <libraries>
+            <library>
+              <type>executable</type>
+              <!-- <linkCPP>false</linkCPP> -->
+              <dependencyBindings>
+                <dependencyBinding>it0040-lib-sharedstatic:static</dependencyBinding>
+              </dependencyBindings>
+            </library>
+          </libraries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  
+  <dependencies>
+    <dependency>
+      <groupId>com.github.maven-nar.its.nar</groupId>
+      <artifactId>it0040-lib-sharedstatic</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>nar</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/it0040-multi-libtype/it0040-dep-lib-static/src/main/c/HelloWorldExe.c
+++ b/src/it/it0040-multi-libtype/it0040-dep-lib-static/src/main/c/HelloWorldExe.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+int main(int argc, char *argv[]) {
+	printf("%s\n", HelloWorldLib_sayHello());
+	return 0;
+}
+
+

--- a/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/pom.xml
+++ b/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it0040-pom</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>it0040-lib-sharedstatic</artifactId>
+  <packaging>nar</packaging>
+  
+  <name>NAR Shared + Static Library</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    A library with both shared and static and test file
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <properties>
+    <skipTests>true</skipTests>
+  </properties>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>nar-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+            <!--<output>${project.artifactId}</output>  windows better to not have version on artifact -->
+            <libraries>
+              <library>
+                <type>static</type>
+              </library>
+            </libraries>
+          <!--  <tests>
+              <test>
+                <name>HelloWorldTest</name>
+                <link>shared</link>
+              </test>
+            </tests> -->
+        </configuration>
+		<executions>
+		  <execution>
+		    <id>shared</id>
+		    <goals>
+		      <goal>nar-download</goal>
+		      <goal>nar-unpack</goal>
+		      <goal>nar-compile</goal>
+		      <goal>nar-test-unpack</goal>
+		      <goal>nar-testCompile</goal>
+		      <goal>nar-test</goal>
+		    </goals>
+            <configuration>
+              <libraries combine.self="override">
+                <library>
+                  <type>shared</type>
+                </library>
+              </libraries>
+              <c>
+                <defines>
+                  <define>LIB_EXPORTS</define>
+                </defines>
+              </c>
+            </configuration>
+		  </execution>
+		</executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/main/c/HelloWorldLib.c
+++ b/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/main/c/HelloWorldLib.c
@@ -1,0 +1,26 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+char* HelloWorldLib_sayHello() {
+	return "Hello NAR LIB World!";
+}
+

--- a/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/main/include/HelloWorldLib.h
+++ b/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/main/include/HelloWorldLib.h
@@ -1,0 +1,43 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#ifndef HelloWorldLib_H
+#define HelloWorldLib_H
+
+#ifdef WIN32
+#ifdef LIB_EXPORTS
+#pragma message( "Export" )
+#define LIB_EXPORT __declspec(dllexport)
+#else
+#ifdef LIB_IMPORTS
+#pragma message( "Import" )
+#define LIB_EXPORT __declspec(dllimport)
+#else
+#pragma message( "Static" )
+#define LIB_EXPORT
+#endif
+#endif
+#else
+#define LIB_EXPORT
+#endif
+
+
+LIB_EXPORT extern char* HelloWorldLib_sayHello();
+
+#endif

--- a/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/test/c/HelloWorldTest.c
+++ b/src/it/it0040-multi-libtype/it0040-lib-sharedstatic/src/test/c/HelloWorldTest.c
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Native ARchive plugin for Maven
+ * %%
+ * Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+#include <stdio.h>
+#include "HelloWorldLib.h"
+
+int main(int argc, char *argv[]) {
+	printf("%s\n", HelloWorldLib_sayHello());
+	return 0;
+}
+
+

--- a/src/it/it0040-multi-libtype/pom.xml
+++ b/src/it/it0040-multi-libtype/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Native ARchive plugin for Maven
+  %%
+  Copyright (C) 2002 - 2014 NAR Maven Plugin developers.
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.maven-nar.its.nar</groupId>
+    <artifactId>it-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../it-parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>it0040-pom</artifactId>
+  <packaging>pom</packaging>
+  
+  <name>NAR Multi Module</name>
+  <version>1.0-SNAPSHOT</version>  
+  <description>
+    Simple Multi Module project
+  </description>
+  <url>http://maven.apache.org/</url>
+
+  <build>
+    <defaultGoal>integration-test</defaultGoal>
+<!--
+    <defaultGoal>install</defaultGoal>
+-->
+  </build>
+
+  <modules>
+    <module>it0040-lib-sharedstatic</module>
+    <module>it0040-dep-lib-default</module>
+    <module>it0040-dep-lib-shared</module>
+    <module>it0040-dep-lib-static</module>
+  </modules>
+</project>

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -145,7 +145,7 @@ public class NarCompileMojo extends AbstractCompileMojo {
 
     // object directory
     File objDir = new File(getTargetDirectory(), "obj");
-    objDir = new File(objDir, getAOL().toString());
+    objDir = new File(objDir, getAOL().toString() + "-" + library.getType());
     objDir.mkdirs();
     task.setObjdir(objDir);
 

--- a/src/main/java/com/github/maven_nar/NarCompileMojo.java
+++ b/src/main/java/com/github/maven_nar/NarCompileMojo.java
@@ -371,8 +371,9 @@ public class NarCompileMojo extends AbstractCompileMojo {
 
         // FIXME no handling of "local"
 
-        // FIXME, no way to override this at this stage
-        final String binding = dependency.getNarInfo().getBinding(getAOL(), Library.NONE);
+        String binding = getBinding(library, dependency);
+        if (binding == null)
+            binding = dependency.getNarInfo().getBinding(getAOL(), Library.NONE);
         getLog().debug("Using Binding: " + binding);
         AOL aol = getAOL();
         aol = dependency.getNarInfo().getAOL(getAOL());

--- a/src/main/java/com/github/maven_nar/NarLayout21.java
+++ b/src/main/java/com/github/maven_nar/NarLayout21.java
@@ -233,12 +233,13 @@ public class NarLayout21 extends AbstractNarLayout {
         } else {
           // if the binding is already set, then don't write it for
           // jni/executable/none.
-          if (narInfo.getBinding(aol, null) == null) {
+		  String current = narInfo.getBinding(aol, null);
+          if ( current == null) {
             narInfo.setBinding(aol, type);
-          } else if (type.equals(Library.STATIC)) {
+          } else if (!Library.SHARED.equals(current)
+			  && type.equals(Library.STATIC)) {
             //static lib is preferred over other remaining types; see #231
             narInfo.setBinding(aol, type);
-            narInfo.setBinding(null, type);
           }
 
           if (narInfo.getBinding(null, null) == null) {


### PR DESCRIPTION
Aiming to address #368

Fix to apply the precedence in binding shared/static or others

Add a unit test that 
 * creates a static and shared library in 1 build
 * depends on the library using
   * default
   * shared specific
   * static specific

Enhance auto-configuration of intermediate obj folder to acknowledge lib type