### PR TITLE
Fix passing certain gcc/g++ arguments to linker (issue #390)

### DIFF
--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -44,7 +44,9 @@ public class GccLinker extends AbstractLdLinker {
       "-bundle",
       // FREEHEP
       "-dynamic", "-arch", "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s", "-static", "-shared",
-      "-symbolic", "-Xlinker", "--export-all-symbols", "-static-libgcc", "-p", "-pg", "-pthread"
+      "-symbolic", "-Xlinker", "--export-all-symbols", "-static-libgcc", "-p", "-pg", "-pthread",
+      // Regex based
+      "-specs=.*", "-std=.*"
   };
   // FREEHEP refactored dllLinker to soLinker
   private static final GccLinker soLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", false,
@@ -125,7 +127,7 @@ public class GccLinker extends AbstractLdLinker {
         default:
           boolean known = false;
           for (final String linkerOption : linkerOptions) {
-            if (linkerOption.equals(arg)) {
+            if (arg.matches(linkerOption)) {
               known = true;
               break;
             }

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GccLinker.java
@@ -46,7 +46,7 @@ public class GccLinker extends AbstractLdLinker {
       "-dynamic", "-arch", "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s", "-static", "-shared",
       "-symbolic", "-Xlinker", "--export-all-symbols", "-static-libgcc", "-p", "-pg", "-pthread",
       // Regex based
-      "-specs=.*", "-std=.*"
+      "-specs=.*", "-std=.*", "--specs=.*", "--std=.*"
   };
   // FREEHEP refactored dllLinker to soLinker
   private static final GccLinker soLinker = new GccLinker("gcc", objFiles, discardFiles, "lib", ".so", false,

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -47,7 +47,9 @@ public class GppLinker extends AbstractLdLinker {
   };
   private static String[] linkerOptions = new String[] {
       "-bundle", "-dylib", "-dynamic", "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s", "-static",
-      "-shared", "-symbolic", "-Xlinker", "-static-libgcc", "-shared-libgcc", "-p", "-pg", "-pthread"
+      "-shared", "-symbolic", "-Xlinker", "-static-libgcc", "-shared-libgcc", "-p", "-pg", "-pthread",
+      // Regex based
+      "-specs=.*", "-std=.*"
   };
   // FREEHEP refactored dllLinker into soLinker
   private static final GppLinker soLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".so", false,
@@ -230,7 +232,7 @@ public class GppLinker extends AbstractLdLinker {
         default:
           boolean known = false;
           for (final String linkerOption : linkerOptions) {
-            if (linkerOption.equals(arg)) {
+            if (arg.matches(linkerOption)) {
               known = true;
               break;
             }

--- a/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/gcc/GppLinker.java
@@ -49,7 +49,7 @@ public class GppLinker extends AbstractLdLinker {
       "-bundle", "-dylib", "-dynamic", "-dynamiclib", "-nostartfiles", "-nostdlib", "-prebind", "-s", "-static",
       "-shared", "-symbolic", "-Xlinker", "-static-libgcc", "-shared-libgcc", "-p", "-pg", "-pthread",
       // Regex based
-      "-specs=.*", "-std=.*"
+      "-specs=.*", "-std=.*", "--specs=.*", "--std=.*"
   };
   // FREEHEP refactored dllLinker into soLinker
   private static final GppLinker soLinker = new GppLinker(GPP_COMMAND, objFiles, discardFiles, "lib", ".so", false,


### PR DESCRIPTION
These are the changes mentioned in that issue, changing linkerOptions into regex, and adding the new entries.