### PR TITLE
Handle NPEs better - config errors logged as Warn; mitigate usage errors

### DIFF
--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -263,7 +263,6 @@ public abstract class Compiler {
       this.mojo.getLog().warn("NAR configuration: empty " + configName + " - ignoring");
       return null;
     }
-    final DefineArgument define = new DefineArgument();
     final String[] pair = argument.split("=", 2);
 
     if (pair[0].equals("")) {
@@ -271,6 +270,7 @@ public abstract class Compiler {
         return null;
     }
 
+    final DefineArgument define = new DefineArgument();
     define.setName(pair[0]);
     define.setValue(pair.length > 1 ? cleanDefineValue(pair[1]) : null);
     return define;

--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -269,7 +269,7 @@ public abstract class Compiler {
     if (pair[0].equals("")) {
         this.mojo.getLog().warn("NAR configuration: definition has no name in " + configName + " - ignoring");
         return null;
-      }
+    }
 
     define.setName(pair[0]);
     define.setValue(pair.length > 1 ? cleanDefineValue(pair[1]) : null);

--- a/src/main/java/com/github/maven_nar/Compiler.java
+++ b/src/main/java/com/github/maven_nar/Compiler.java
@@ -251,6 +251,32 @@ public abstract class Compiler {
   }
 
   /**
+   * Parses a "NAME=VALUE" string into a name and (optional) value. Logs to warn if argument is null, implying a blank 
+   * config item (eg &lt;define>&lt;/define>, or &lt;define>${x}&lt;/define> when x is undefined).
+   * 
+   * @param argument the string to parse (may be null)
+   * @param configName the name of the argument type, for logging purposes
+   * @return the parsed DefineArgument, or null if argument is null
+   */
+  private DefineArgument parseDefineArgument(final String argument, String configName) {
+    if (argument == null) {
+      this.mojo.getLog().warn("NAR configuration: empty " + configName + " - ignoring");
+      return null;
+    }
+    final DefineArgument define = new DefineArgument();
+    final String[] pair = argument.split("=", 2);
+
+    if (pair[0].equals("")) {
+        this.mojo.getLog().warn("NAR configuration: definition has no name in " + configName + " - ignoring");
+        return null;
+      }
+
+    define.setName(pair[0]);
+    define.setValue(pair.length > 1 ? cleanDefineValue(pair[1]) : null);
+    return define;
+  }
+  
+  /**
    * Filter elements such as cr\lf that are problematic when used inside a `define`
    *  
    * @param value  define value to be cleaned
@@ -328,13 +354,10 @@ public abstract class Compiler {
     }
 
     if (this.optionSet != null) {
-
       final String[] opts = this.optionSet.split("\\s");
 
       for (final String opt : opts) {
-
         final CompilerArgument arg = new CompilerArgument();
-
         arg.setValue(opt);
         compilerDef.addConfiguredCompilerArg(arg);
       }
@@ -358,31 +381,24 @@ public abstract class Compiler {
     if (this.defines != null) {
       final DefineSet ds = new DefineSet();
       for (final String string : this.defines) {
-        final DefineArgument define = new DefineArgument();
-        final String[] pair = string.split("=", 2);
-        define.setName(pair[0]);
-        define.setValue(pair.length > 1 ? cleanDefineValue(pair[1]) : null);
-        ds.addDefine(define);
+        final DefineArgument define = parseDefineArgument(string, "define");
+        if (define != null) {
+          ds.addDefine(define);
+        }
       }
       compilerDef.addConfiguredDefineset(ds);
     }
 
     if (this.defineSet != null) {
-
       final String[] defList = this.defineSet.split(",");
       final DefineSet defSet = new DefineSet();
 
       for (final String element : defList) {
-
-        final String[] pair = element.trim().split("=", 2);
-        final DefineArgument def = new DefineArgument();
-
-        def.setName(pair[0]);
-        def.setValue(pair.length > 1 ? cleanDefineValue(pair[1]) : null);
-
-        defSet.addDefine(def);
+          final DefineArgument define = parseDefineArgument(element, "defineSet");
+          if (define != null) {
+              defSet.addDefine(define);
+          }
       }
-
       compilerDef.addConfiguredDefineset(defSet);
     }
 
@@ -400,11 +416,10 @@ public abstract class Compiler {
     if (this.undefines != null) {
       final DefineSet us = new DefineSet();
       for (final String string : this.undefines) {
-        final DefineArgument undefine = new DefineArgument();
-        final String[] pair = string.split("=", 2);
-        undefine.setName(pair[0]);
-        undefine.setValue(pair.length > 1 ? pair[1] : null);
-        us.addUndefine(undefine);
+        final DefineArgument undef = parseDefineArgument(string, "undefine");
+        if (undef != null) {
+            us.addUndefine(undef);
+        }
       }
       compilerDef.addConfiguredDefineset(us);
     }
@@ -415,16 +430,11 @@ public abstract class Compiler {
       final DefineSet undefSet = new DefineSet();
 
       for (final String element : undefList) {
-
-        final String[] pair = element.trim().split("=", 2);
-        final DefineArgument undef = new DefineArgument();
-
-        undef.setName(pair[0]);
-        undef.setValue(pair.length > 1 ? pair[1] : null);
-
-        undefSet.addUndefine(undef);
+        final DefineArgument undef = parseDefineArgument(element, "undefineSet");
+        if (undef != null) {
+            undefSet.addUndefine(undef);
+        }
       }
-
       compilerDef.addConfiguredDefineset(undefSet);
     }
 

--- a/src/main/java/com/github/maven_nar/IncludePath.java
+++ b/src/main/java/com/github/maven_nar/IncludePath.java
@@ -85,4 +85,9 @@ public class IncludePath {
     this.path = path;
     this.file = new File(path);
   }
+
+  @Override
+  public String toString() {
+    return getPath() + (includes == null ? "" : "[" + getIncludes() + "]");
+  }
 }

--- a/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
+++ b/src/main/java/com/github/maven_nar/cpptasks/CUtil.java
@@ -26,10 +26,8 @@ import java.util.*;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.taskdefs.Execute;
-import org.apache.tools.ant.taskdefs.LogStreamHandler;
 import org.apache.tools.ant.types.Commandline;
 import org.apache.tools.ant.types.Environment;
-import org.apache.tools.ant.util.StringUtils;
 
 /**
  * Some utilities used by the CC and Link tasks.
@@ -421,7 +419,8 @@ public class CUtil {
       return exe.execute();
             */
 
-	  return CommandExecution.runCommand(cmdline,workingDir,task,env.getVariablesVector());
+      return CommandExecution.runCommand(cmdline, workingDir, task, 
+              env == null ? new Vector<Environment.Variable>() : env.getVariablesVector());
     } catch (final java.io.IOException exc) {
       throw new BuildException("Could not launch " + cmdline[0] + ": " + exc, task.getLocation());
     }
@@ -502,14 +501,14 @@ public class CUtil {
 
   public static String toUnixPath(final String path) {
     if (File.separatorChar != '/' && path.indexOf(File.separatorChar) != -1) {
-      return StringUtils.replace(path, File.separator, "/");
+      return path.replace(File.separator, "/");
     }
     return path;
   }
 
   public static String toWindowsPath(final String path) {
     if (File.separatorChar != '\\' && path.indexOf(File.separatorChar) != -1) {
-      return StringUtils.replace(path, File.separator, "\\");
+      return path.replace(File.separator, "\\");
     }
     return path;
   }


### PR DESCRIPTION
1. Plugin fails with NPE when user provides empty definitions eg &lt;define>&lt;/define> - which can happen innocently when a Maven property is empty (eg &lt;define>${foo}&lt;/define>). I've changed it to log a WARN now, because it's probably caused by a config error (it was in my case!), and the user probably wants to know about it. I've factored out the '='-splitting code, because we do that in a few cases (not all of them can fail this way, but I think it's better to do the parsing in one place). 
2. In CUtil.runCommand, it was assumed that the Environment env is non-null when it extracts the Variables vector, but the various usages presume it can be null, resulting in NPE. I've softened it up to produce an empty vector instead.
3. Updated deprecated calls to StringUtil.replace.